### PR TITLE
Add menu item and page for financial assitance

### DIFF
--- a/2019/financial_assistance.html
+++ b/2019/financial_assistance.html
@@ -1,0 +1,35 @@
+---
+layout: default2019
+permalink: /2019/financial-assistance
+---
+
+{% include_relative header19.html %}
+
+{% include_relative menubar.html %}
+
+<div class="u-vskip-3"></div>
+
+<div class="container">
+
+<h1>Financial Assistance</h1>
+  <p>
+    JuliaCon 2019 aims to be an inclusive event. In an effort to reduce the degree to which cost may deter community members from attending this event, we offer financial assistance to GSoC students, accepted speakers, and attendees who heighten the diversity of the Julia community. We welcome participation from people of all races, ethnicities, genders, ages, abilities, religions, sexual orientations, personal/professional backgrounds, and schools of thought.
+  </p><p>
+    If financial assistance will impact your ability to attend JuliaCon 2019, please fill out this <a href="https://goo.gl/forms/0TbdyBFudkzNtcmM2">application</a>.
+  </p>
+
+  <h2>Timeline</h2>
+  <p>
+    <ul>
+      <li> March 22, 2019 23:59 AoE (Anywhere on Earth) &#9964; Deadline for submission.
+      <li> April 25, 2019 &#9964; Notification for financial assistance awarded.
+      <li> May 9, 2019 &#9964; Deadline to accept/decline financial assistance.
+    </ul>
+  </p>
+
+</div>
+
+<div class="u-vskip-3"></div>
+
+
+{% include_relative footer_container19.html %}

--- a/2019/menubar.html
+++ b/2019/menubar.html
@@ -26,6 +26,9 @@
           <li class="nav-item">
             <a class="nav-link" href="javascript:alert('coming soon');">talks & workshops</a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="/{{current_folder}}/financial-assistance/">financial assistance</a>
+          </li>
         </ul>
       </div>
     </nav>


### PR DESCRIPTION
Resolves issue: [Add a new tab on the JuliaCon 2019 homepage for the financial assistance application](https://github.com/JuliaCon/JuliaCon2019/issues/26)