### PR TITLE
add deadlines on banner

### DIFF
--- a/2019/alert.html
+++ b/2019/alert.html
@@ -2,8 +2,8 @@
 <div class="container-fluid earlybird">
   <div class="container">
     <div class="alert">
-       <a href="https://pretalx.com/juliacon2019/">Call for proposals</a> and
-       <a href="/{{current_folder}}/tickets/">Early Bird Ticket Sales</a> now open!
+       <a href="https://pretalx.com/juliacon2019/">Call for Proposals</a> due 2019-03-16 07:55 EDT |
+       <a href="/{{current_folder}}/tickets/">Early Bird Ticket Sale</a> ends 2019-05-05 11:59 EDT
     </div>
   </div>
 </div>


### PR DESCRIPTION
This adds the CfP deadline and the last day for early bird tickets on the top of the banner.

![image](https://user-images.githubusercontent.com/12985181/53943654-6a935280-4072-11e9-818b-5a1809d7fd24.png)


Related issue: #164 