### PR TITLE
To bold the deadlines on top header

### DIFF
--- a/2019/alert.html
+++ b/2019/alert.html
@@ -2,8 +2,8 @@
 <div class="container-fluid earlybird">
   <div class="container">
     <div class="alert">
-       <a href="https://pretalx.com/juliacon2019/">Call for Proposals</a> due 2019-03-16 07:55 EDT |
-       <a href="/{{current_folder}}/tickets/">Early Bird Ticket Sale</a> ends 2019-05-05 11:59 EDT
+       <a href="https://pretalx.com/juliacon2019/">Call for Proposals</a> due <b>2019-03-16 07:55 EDT</b> |
+       <a href="/{{current_folder}}/tickets/">Early Bird Ticket Sale</a> ends <b>2019-05-05 11:59 EDT</b>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Related issue: #164 

Perhaps having the deadlines in bold would be more noticeable :smiley: 

![image](https://user-images.githubusercontent.com/12985181/53981640-cf2ccc80-40c7-11e9-8895-40ba5e7af3a6.png)

versus

![image](https://user-images.githubusercontent.com/12985181/53981671-e5d32380-40c7-11e9-8e20-989aee3ad3c3.png)
