### PR TITLE
Redirects /2019/cfp/ to Pretalx

### DIFF
--- a/2019/cfp.html
+++ b/2019/cfp.html
@@ -1,6 +1,8 @@
 ---
 layout: default2019
 permalink: /2019/cfp/
+redirect_to:
+  - https://pretalx.com/juliacon2019/
 ---
 
 {% include_relative header19.html %}

--- a/_config.yml
+++ b/_config.yml
@@ -12,3 +12,10 @@ page_gen:
     template: '2018speaker'
     name: 'id'
     dir: '2018/talks_workshops'
+
+plugins:
+  - jekyll-redirect-from
+
+# mimic GitHub Pages: jekyll <cmd> --safe
+whitelist:
+  - jekyll-redirect-from


### PR DESCRIPTION
Uses the plugin "[Jekyll Redirect From](https://help.github.com/en/articles/redirects-on-github-pages)" to redirect `/2019/cfp/` to [https://pretalx.com/juliacon2019/](https://pretalx.com/juliacon2019/)

There was a conversation on the [#juliacon](https://julialang.slack.com/messages/C6J9D5QV6) slack channel where someone went to `/2019/cfp` but received last years content instead. This is just in case if anyone else ends up on `/2019/cfp` and gets confused with the CFP deadline. 

cc: @vchuravy 

