### PR TITLE
Update sitewide contact email

### DIFF
--- a/2015/index.html
+++ b/2015/index.html
@@ -333,7 +333,7 @@
 
   <p>The hotel is within walking distance from MIT. Complimentary shuttle service will also be available. Rooms are newly renovated and with free Internet access. The guest room rates are quoted exclusive of applicable state and local taxes (which are currently 14.45%), applicable service fees, and/or hotel-specific fees in effect at the time of the event.</p>
 
-  <p>Rooms are available from <a href="http://cambridge.hyatt.com/en/hotel/home.html">the Hyatt's website</a> or by calling 888-421-1442. If you have problems booking a room please contact <a href="mailto:Caitlin.Hanna@hyatt.com">Caitlin Hanna</a> and also please let <a href="mailto:juliacon@groups.google.com">us know</a>.</p>
+  <p>Rooms are available from <a href="http://cambridge.hyatt.com/en/hotel/home.html">the Hyatt's website</a> or by calling 888-421-1442. If you have problems booking a room please contact <a href="mailto:Caitlin.Hanna@hyatt.com">Caitlin Hanna</a> and also please let <a href="mailto:juliacon@julialang.org">us know</a>.</p>
 
   <p><strong>The Hyatt Cambridge is sold out for Wednesday, June 24, but rooms are still available for Thursday through Saturday.</strong></p>
 
@@ -342,7 +342,7 @@
 
 <div class="container">
     <h2 class="text-center border-header"><span>Program Committee</span></h2>
-    <p>The JuliaCon program committee is composed of entirely of volunteer organizers and can be reached at juliacon@googlegroups.com with any questions or comments.</p>
+    <p>The JuliaCon program committee is composed of entirely of volunteer organizers and can be reached at <a href="mailto:juliacon@julialang.org">juliacon@julialang.org</a> with any questions or comments.</p>
     <h3>Members</h3>
     <ul>
       <li>Jiahao Chen (Chair)</li>

--- a/2016/index.html
+++ b/2016/index.html
@@ -148,8 +148,8 @@
     <li>Ismael Venegas Castelló (proceedings chair)</li>
   </ul>
   <p><br>The JuliaCon committee is composed entirely of volunteer organizers
-    and can be reached at juliacon@googlegroups.com with any questions
-    or comments.</p>
+    and can be reached at <a href="mailto:juliacon@julialang.org">juliacon@julialang.org</a>
+    with any questions or comments.</p>
 </div>
 
 <div id="accommodations"></div>
@@ -207,7 +207,7 @@
       </table>
     </div>
   </p>
-  <p>For further details on sponsorship, please <a href="mailto:juliacon@googlegroups.com">contact the JuliaCon committee</a>.</p>
+  <p>For further details on sponsorship, please <a href="mailto:juliacon@julialang.org">contact the JuliaCon committee</a>.</p>
   <p style="padding-top: 1em;">JuliaCon 2016 <b>Platinum</b> sponsors:
     <div class="text-center" style="padding-top: 0.5em;">
       <a href="https://www.moore.org/"><img src="images/moore.png" alt="Gordon and Betty Moore Foundation" onerror="this.src='images/moore.png'" width="auto" height="70px"></a>

--- a/2017/cfp.md
+++ b/2017/cfp.md
@@ -59,8 +59,8 @@ please let us know and we will see what we can do.
 * Avoid opaque titles; while witty titles are good, an informative title is essential.
 * Avoid infomercials; while we love to hear how you use Julia in your company,  
   JuliaCon is not the place to sell your product.
-* If you want feedback before submitting a proposal, contact us at `juliacon@googlegroups.com`,
-  well ahead of the deadline.  
+* If you want feedback before submitting a proposal, contact us at 
+  [juliacon@julialang.org](mailto:juliacon@julialang.org), well ahead of the deadline.  
   We are more than happy to help you improve your proposal.
 
 If you have doubts about becoming a speaker, check out the website

--- a/2017/coc.md
+++ b/2017/coc.md
@@ -67,7 +67,7 @@ a recurrence.
 
 You can make a personal report by calling or messaging this phone
 number: (TBD) or this email address
-juliacon@googlegroups.com (private group of the committee).
+[juliacon@julialang.org](mailto:juliacon@julialang.org) (private group of the committee).
 This phone number will be continuously monitored for the duration of the event.
 
 When taking a personal report, our staff will ensure you are safe and

--- a/2017/index.html
+++ b/2017/index.html
@@ -92,7 +92,7 @@ Mykel Kochenderfer is Assistant Professor of Aeronautics and Astronautics and As
       <p>Andreas Noack (executive chair), Valentin Churavy (program chair), Jiahao Chen, David Anthoff, Alex Arslan, Alan Edelman, Shashi Gowda, Katharine Hyatt, Stefan Karpinski, Kevin Keys, Simon Kornblith, Jonathan Malmaud, Erica Moszkowski (diversity chair), Jarrett Revels, Viral B. Shah, David P. Sanders, and Pontus Stenetorp</p>
       <p>
       The JuliaCon committee is composed entirely of volunteer organizers
-      and can be reached at <a href="mailto:juliacon@googlegroups.com">juliacon@googlegroups.com</a>
+      and can be reached at <a href="mailto:juliacon@julialang.org">juliacon@julialang.org</a>
       with any questions or comments.
       </p>
       <div class="u-vskip"></div>

--- a/2018/cfp.html
+++ b/2018/cfp.html
@@ -90,7 +90,7 @@ These mentoring sessions can cover any of the following:</p>
   <li>Try not to assume familiarity with your subject when writing the abstract; the average reader is most likely not an expert in your area of expertise.</li>
   <li>Avoid opaque titles; while witty titles are good, an informative title is essential.</li>
   <li>Avoid infomercials; while we love to hear how you use Julia in your company, JuliaCon is not the place to sell your product.</li>
-  <li>If you want feedback before submitting a proposal or if you are interested in the mentorship program, contact us at juliacon@googlegroups.com well ahead of the deadline.</li>
+  <li>If you want feedback before submitting a proposal or if you are interested in the mentorship program, contact us at <a href="mailto:juliacon@julialang.org">juliacon@julialang.org</a> well ahead of the deadline.</li>
 </ul>
 
 <p>If you have doubts about becoming a speaker, check out the website <a href="http://weareallaweso.me/" target="_blank" rel="nofollow">We are all awesome</a>.<br>
@@ -113,7 +113,7 @@ Finally, we also ask you to make your materials and recording available under a 
 
 <h3>How to contact us</h3>
 
-<p>You can reach us with question and concerns at <a href="mailto:juliacon@googlegroups.com">juliacon@googlegroups.com</a> or on Twitter as <a href="https://twitter.com/JuliaCon2018" target="_blank" rel="nofollow">@JuliaCon2018</a></p>
+<p>You can reach us with questions and concerns at <a href="mailto:juliacon@julialang.org">juliacon@julialang.org</a> or on Twitter as <a href="https://twitter.com/JuliaCon2018" target="_blank" rel="nofollow">@JuliaCon2018</a></p>
 </div>
 
 <div class="u-vskip-3"></div>

--- a/2018/coc.html
+++ b/2018/coc.html
@@ -64,7 +64,8 @@ layout: default2018
   <p>
     Please call or message this phone
     number: +44 7920402037 or this email address
-    juliacon@googlegroups.com (private group of the committee)
+    <a href="mailto:juliacon@julialang.org">juliacon@julialang.org</a>
+    (private group of the committee)
     to make a personal report or to discuss any incident that may have
     left you uncomfortable. This number and email address will be
     continuously monitored for the duration of the event.

--- a/2018/tickets.html
+++ b/2018/tickets.html
@@ -33,7 +33,7 @@ layout: default2018
   </p>
 
   <h3>Contact the Organizers</h3>
-  <p>Please email <a href="mailto:contact@juliacon.org">contact@juliacon.org</a> with any questions, comments or suggestions.
+  <p>Please email <a href="mailto:juliacon@julialang.org">juliacon@julialang.org</a> with any questions, comments or suggestions.
   </p>
 
   <h3>Ticket Prices</h3>

--- a/2019/cfp.html
+++ b/2019/cfp.html
@@ -93,7 +93,7 @@ These mentoring sessions can cover any of the following:</p>
   <li>Try not to assume familiarity with your subject when writing the abstract; the average reader is most likely not an expert in your area of expertise.</li>
   <li>Avoid opaque titles; while witty titles are good, an informative title is essential.</li>
   <li>Avoid infomercials; while we love to hear how you use Julia in your company, JuliaCon is not the place to sell your product.</li>
-  <li>If you want feedback before submitting a proposal or if you are interested in the mentorship program, contact us at juliacon@googlegroups.com well ahead of the deadline.</li>
+  <li>If you want feedback before submitting a proposal or if you are interested in the mentorship program, contact us at <a href="mailto:juliacon@julialang.org">juliacon@julialang.org</a> well ahead of the deadline.</li>
 </ul>
 
 <p>If you have doubts about becoming a speaker, check out the website <a href="http://weareallaweso.me/" target="_blank" rel="nofollow">We are all awesome</a>.<br>
@@ -116,7 +116,7 @@ Finally, we also ask you to make your materials and recording available under a 
 
 <h3>How to contact us</h3>
 
-<p>You can reach us with question and concerns at <a href="mailto:juliacon@googlegroups.com">juliacon@googlegroups.com</a> or on Twitter as <a href="https://twitter.com/JuliaCon2018" target="_blank" rel="nofollow">@JuliaCon2018</a></p>
+<p>You can reach us with questions and concerns at <a href="mailto:juliacon@julialang.org">juliacon@julialang.org</a> or on Twitter as <a href="https://twitter.com/JuliaCon2018" target="_blank" rel="nofollow">@JuliaCon2018</a></p>
 </div>
 
 <div class="u-vskip-3"></div>

--- a/2019/tickets.html
+++ b/2019/tickets.html
@@ -32,7 +32,7 @@ permalink: /2019/tickets/
   </p>
 
   <h3>Contact the Organizers</h3>
-  <p>Please email <a href="mailto:contact@juliacon.org">contact@juliacon.org</a> with any questions, comments or suggestions.
+  <p>Please email <a href="mailto:juliacon@julialang.org">juliacon@julialang.org</a> with any questions, comments or suggestions.
   </p>
 
   <h3>Full Price Tickets</h3>

--- a/_includes/content.html
+++ b/_includes/content.html
@@ -156,7 +156,7 @@ He blogs on www.walkingrandomly.com and tweets at @walkingrandomly" %}</p>
 
         <p>
           The JuliaCon committee is composed entirely of volunteer organizers
-          and can be reached at <a href="mailto:juliacon@googlegroups.com">juliacon@googlegroups.com</a>
+          and can be reached at <a href="mailto:juliacon@julialang.org">juliacon@julialang.org</a>
           with any questions or comments.
         </p>
       </div>

--- a/staging/coc.md
+++ b/staging/coc.md
@@ -67,7 +67,7 @@ a recurrence.
 
 You can make a personal report by calling or messaging this phone
 number: (TBD) or this email address
-juliacon@googlegroups.com (private group of the committee).
+[juliacon@julialang.org](mailto:juliacon@julialang.org) (private group of the committee).
 This phone number will be continuously monitored for the duration of the event.
 
 When taking a personal report, our staff will ensure you are safe and


### PR DESCRIPTION
Long overdue change. 

Related issues: [#33](https://github.com/JuliaCon/JuliaCon2019/issues/23) and #158 .  

Hopefully, anyone who had trouble contacting the committee would have seen this announcement thread on [discourse](https://discourse.julialang.org/t/juliacon-2019-july-21st-to-27th-in-baltimore-md-usa/18750/17).  