### PR TITLE
Add ticket sale countdown timer

### DIFF
--- a/2019/alert.html
+++ b/2019/alert.html
@@ -1,9 +1,10 @@
 {% assign current_folder = "2019" %}
+
 <div class="container-fluid earlybird">
   <div class="container">
     <div class="alert">
-       <a href="https://pretalx.com/juliacon2019/">Call for Proposals</a> now closed |
-       <a href="/{{current_folder}}/tickets/">Early Bird Ticket Sale</a> ends <b>2019-05-10 11:59 EDT</b>
+      <a href="https://pretalx.com/juliacon2019/">Call for Proposals</a> now closed |
+      <span id="ticket-timer-text"></span><span id="ticket-timer"></span>
     </div>
   </div>
 </div>
@@ -14,3 +15,4 @@
     </div>
   </div>
 </div>
+<script src="/{{current_folder}}/assets/js/ticket-timer.js"></script>

--- a/2019/assets/js/ticket-timer.js
+++ b/2019/assets/js/ticket-timer.js
@@ -1,0 +1,60 @@
+/*
+Time in EDT or EST
+Mar 10, 2019 - Daylight Saving Time Started: GMT-04:00
+Nov 3, 2019 - Daylight Saving Time Ends: GMT-05:00
+*/
+
+var earlyBird = new Date("May 10, 2019 23:59:59 GMT-04:00").getTime();
+var regular = new Date("July 22, 2019 23:59:59 GMT-04:00").getTime();
+
+/*
+countdown:
+- date to countdown to
+- text as to prelude the countdown
+- setInterval id
+*/
+function countdown(date, id){
+
+    var counting = document.getElementById("ticket-timer");
+
+    // Get todays date and time
+    var now = new Date().getTime();
+
+    // Find the distance between now and the count down date
+    var distance = date - now;
+
+    // Time calculations for days, hours, minutes and seconds
+    var days = Math.floor(distance / (1000 * 60 * 60 * 24));
+    var hours = Math.floor((distance % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+    var minutes = Math.floor((distance % (1000 * 60 * 60)) / (1000 * 60));
+    var seconds = Math.floor((distance % (1000 * 60)) / 1000);
+
+    counting.innerHTML = "<b>" + days + "d " + hours + "h " + minutes + "m " + seconds + "s </b> EDT";
+
+    if (distance < 0) {
+        // stop countdown
+        clearInterval(id);
+        counting.innerHTML = "now closed";
+    }
+}
+
+if( (earlyBird - new Date().getTime()) > 0 ){
+
+    $("#ticket-timer-text").html("<a href='/{{current_folder}}/tickets/'>Early Bird Ticket Sale </a>");
+
+    // Update countdown every 1 second
+    var cd1 = setInterval(
+        countdown.bind( null,
+        earlyBird,
+        cd1), 1000);
+}
+else {
+
+    $("#ticket-timer-text").html("<a href='/{{current_folder}}/tickets/'>Ticket Sale </a>");
+
+    // possible to do "function(){ countdown(params) }" instead of "countdown.bind(null, params)"
+    var cd2 = setInterval(
+        countdown.bind( null,
+        regular,
+        cd2), 1000);
+}


### PR DESCRIPTION
This adds a countdown timer to the alert banner for pages `/2019/*`. 

`ticket-timer.js` counts down to May 10th for the end of Early bird ticket sales. The next time the page reloads, the countdown counts to July 22nd for regular ticket sales.

Here's an example:
![demo-timer2](https://user-images.githubusercontent.com/12985181/57172644-82b7f180-6dd7-11e9-9f56-2cb060dd30e3.gif)

What it will look like on the site:
![demo-timer3](https://user-images.githubusercontent.com/12985181/57172646-8a779600-6dd7-11e9-8673-e7f872133ac5.gif)

I've used these sites as reference to make sure that the time remaining was consistent:
[Earlybird Countdown](https://www.timeanddate.com/countdown/vacation?iso=20190510T235959&p0=179&msg=Early+Bird&font=cursive)
[Regular Ticket Sale Countdown](https://www.timeanddate.com/countdown/launch?iso=20190722T235959&p0=419&msg=Regular+Sale&font=cursive)