### PR TITLE
hide waving flag animation from mobile view in menubar

### DIFF
--- a/2019/assets/css/style.css
+++ b/2019/assets/css/style.css
@@ -647,3 +647,10 @@ h1, h2, h3, h4, h5, h6 {
 .sponsors_img_l1 { max-width: 350px; max-height: 200px; overflow: hidden; display: inline-block; }
 .sponsors_img_l2 { max-width: 300px; max-height: 80px; overflow: hidden; display: inline-block; }
 .sponsors_img_l3 { max-width: 150px; max-height: 40px; overflow: hidden; display: inline-block; }
+
+@media screen and (max-width: 600px) {
+    #waving-flag{
+        display: none;
+        visibility: hidden;
+    }
+}

--- a/2019/menubar.html
+++ b/2019/menubar.html
@@ -8,7 +8,7 @@
       </button>
       <div class="collapse navbar-collapse" id="navbarNavDropdown">
         <ul class="navbar-nav">
-          <li>
+          <li id="waving-flag">
             <img src="/{{current_folder}}/assets/img/waving-flag.gif" style="position: relative; top: 10pt; height: 64pt; margin-top: -42pt;">
           </li>
           <li class="nav-item">


### PR DESCRIPTION
I've noticed that the waving flag gif was in the way of the menubar icon, shown below:
![image](https://user-images.githubusercontent.com/12985181/61632827-9dfe0480-ac42-11e9-8c7c-088bf60d591c.png)


This fix hides the gif from mobile view:
![image](https://user-images.githubusercontent.com/12985181/61632818-963e6000-ac42-11e9-9bbc-134f3bbd471e.png)
