### PR TITLE
Add date/time for CfP deadline on front page

### DIFF
--- a/2020/alert.html
+++ b/2020/alert.html
@@ -3,7 +3,7 @@
 <div class="container-fluid earlybird">
   <div class="container">
     <div class="alert">
-      <a href="https://juliacon.org/2020/tickets/">Early Bird Tickets</a> are on sale | <a href="https://pretalx.com/juliacon2020/cfp">Call for Proposals</a>
+      <a href="https://juliacon.org/2020/tickets/">Early Bird Tickets</a> are on sale | <a href="https://pretalx.com/juliacon2020/cfp">Call for Proposals</a> closes on March 7 at 14:58 (UTC)
     </div>
   </div>
 </div> 


### PR DESCRIPTION
I came looking for this and it took too long to find it (it's at the very bottom of the pretalx site).  This is the trivial fix.

Bonus points if someone can javascriptedly make this count down (e.g., closes in 4 days 20 hours), but that someone is not going to be me.