### PR TITLE
Fix the link to ticketing in the alert banner

### DIFF
--- a/2020/alert.html
+++ b/2020/alert.html
@@ -3,7 +3,7 @@
 <div class="container-fluid earlybird">
   <div class="container">
     <div class="alert">
-      <a href="/tickets/">Register for free</a> for our  <a href="/2020/covid19">online event</a>
+      <a href="/2020/tickets/">Register for free</a> for our  <a href="/2020/covid19">online event</a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
The link to the `tickets` page was broken. This should fix it.