### PR TITLE
change meta description in layout

### DIFF
--- a/_layouts/default2020.html
+++ b/_layouts/default2020.html
@@ -14,7 +14,7 @@
     <meta property="og:site_name" content="JuliaCon 2020" />
     <meta property="og:type" content="website" />
     <meta property="og:title" content="JuliaCon 2020" />
-    <meta property="og:description" content="{%if page.title %}{{page.title}} &mdash; {%endif%}JuliaCon 2020, Lisbon, Portugal" />
+    <meta property="og:description" content="{%if page.title %}{{page.title}} &mdash; {%endif%}JuliaCon 2020, Everywhere on Earth" />
     <meta property="og:url" content="http://juliacon.org/2020/" />
     <meta property="og:image" content="http://juliacon.org/2020/assets/img/lisbon-details-2800-mod.png" />
     <meta property="og:image:type" content="image/png" />


### PR DESCRIPTION
As JuliaCon 2020 will be everywhere on Earth (🎉 ), the description in the meta tags needs to be updated.