### PR TITLE
Add link to schedule on pretalx

### DIFF
--- a/2020/menubar.html
+++ b/2020/menubar.html
@@ -18,6 +18,9 @@
             <a class="nav-link" href="/{{current_folder}}/tickets/">Register</a>
           </li>
           <li class="nav-item">
+            <a class="nav-link" href="https://pretalx.com/juliacon2020/schedule/">Schedule</a>
+          </li>
+          <li class="nav-item">
             <a class="nav-link" href="/{{current_folder}}/volunteer/">Volunteer</a>
           </li>
           <li class="nav-item">

--- a/2020/menubar.html
+++ b/2020/menubar.html
@@ -18,7 +18,7 @@
             <a class="nav-link" href="/{{current_folder}}/tickets/">Register</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="https://pretalx.com/juliacon2020/schedule/">Schedule</a>
+            <a class="nav-link" href="https://pretalx.com/juliacon2020/schedule/#2020-07-29">Schedule</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="/{{current_folder}}/volunteer/">Volunteer</a>


### PR DESCRIPTION
Not sure what's the best option between https://pretalx.com/juliacon2020/schedule/ (it shows and empty schedule, which can confuse people) or https://pretalx.com/juliacon2020/schedule/#2020-07-29 (schedule of the first day of the conference)