### PR TITLE
link to webapp

### DIFF
--- a/2020/menubar.html
+++ b/2020/menubar.html
@@ -18,7 +18,7 @@
             <a class="nav-link" href="/{{current_folder}}/tickets/">Register</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="https://pretalx.com/juliacon2020/schedule/#2020-07-29">Schedule</a>
+            <a class="nav-link" href="https://juliacon2020.now.sh/agenda">Schedule</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="/{{current_folder}}/volunteer/">Volunteer</a>


### PR DESCRIPTION
Instead of linking to pretalx for the schedule, link to the webapp agenda.  We'll probably want to think about how we link out to the web app more generally, but it's not fully ready yet.