### PR TITLE
Change default image?

### DIFF
--- a/_layouts/default2020.html
+++ b/_layouts/default2020.html
@@ -16,7 +16,7 @@
     <meta property="og:title" content="JuliaCon 2020" />
     <meta property="og:description" content="{%if page.title %}{{page.title}} &mdash; {%endif%}JuliaCon 2020, Everywhere on Earth" />
     <meta property="og:url" content="http://juliacon.org/2020/" />
-    <meta property="og:image" content="http://juliacon.org/2020/assets/img/lisbon-details-2800-mod.png" />
+    <meta property="og:image" content="https://github.com/cormullion/graphics/blob/master/juliacon2020/juliacon2020-dark.png" />
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="2800" />
     <meta property="og:image:height" content="860" />


### PR DESCRIPTION
As it appears on facebook, twitter and linkedin, juliacon.org comes with a "Lisbon" thumbnail. Wondering if this is the right place to change that. 