### PR TITLE
Fix typo

### DIFF
--- a/2021/committee.html
+++ b/2021/committee.html
@@ -33,4 +33,3 @@ permalink: /2021/committee/
 <div class="u-vskip-3"></div>
 
 {% include_relative footer_container.html %}
-co-


### PR DESCRIPTION
There seems to be “co-“ written at the bottom of the committee page, which looks like a mistake.