### PR TITLE
pretalx link for proposals

### DIFF
--- a/_layout/nav.html
+++ b/_layout/nav.html
@@ -17,7 +17,7 @@
             <a class="nav-link" href="/2021/tickets/">Register</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="javascript:alert('Coming Soon!');">Submit a Proposal</a>
+            <a class="nav-link" href="https://pretalx.com/juliacon2021/cfp">Submit a Proposal</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="javascript:alert('Coming Soon!');">Schedule</a>


### PR DESCRIPTION
This adds back the link to the pretalx

Note to @travigd and @aviks I see some recent changes: https://github.com/JuliaCon/www.juliacon.org/compare/45660d0..a852122

I did not migrate those. Could you check whether what was fixed still needs fixing and if so open an issue? thanks! 🙌 