### PR TITLE
Add CoC to navbar + Add Proceedings box

### DIFF
--- a/2021/index.md
+++ b/2021/index.md
@@ -50,6 +50,10 @@ top_subtitle = "(Workshops in the week earlier)"
   JuliaCon is [organized by a committee](/2021/committee/) composed entirely of volunteers, and can be reached at \email with any questions or comments.
 \end{box}
 
+\begin{box}{title="Proceedings", color="light-blue"}
+  JuliaCon is complemented by the [JuliaCon proceedings](https://proceedings.juliacon.org), an open journal with a formal peer review process for articles that supplement JuliaCon contributions.
+\end{box}
+
 ~~~
 <!-- END of CONTAINER + MASONRY -->
   </div>

--- a/_layout/nav.html
+++ b/_layout/nav.html
@@ -22,6 +22,9 @@
           <li class="nav-item">
             <a class="nav-link" href="javascript:alert('Coming Soon!');">Schedule</a>
           </li>
+          <li class="nav-item">
+            <a class="nav-link" href="/2021/coc/">Code of Conduct</a>
+          </li>
           {{end}}
           {{ispage /2020/*}}
           <li class="nav-item">


### PR DESCRIPTION
As promised in our JCON call today, here comes the PR that
* adds a Code of Conduct entry to the navigation bar and
* adds a Proceedings box to the main page.

![Screenshot 2021-02-17 at 19 50 27](https://user-images.githubusercontent.com/187980/108252850-65454a80-7159-11eb-96c2-e22ab25081fc.png)
