### PR TITLE
Replace markdown table with html table

### DIFF
--- a/2021/workshops.md
+++ b/2021/workshops.md
@@ -2,26 +2,245 @@
 
 Below you will find the workshop schedule along with the link to watch on YouTube. All workshops will be at __(2 PM UTC)__ and as shown below, there will be two workshops running concurrently each day. Make sure you [register (for free)](https://juliacon.org/2021/tickets/) to ensure you are able to participate and ask questions during the workshops.
 
-@@table
-| Date        | Workshop Title  |     Link    |
-| ----------- | ----------- | ----------- |
-| Tuesday July 20      | [GPU programming in Julia](https://pretalx.com/juliacon2021/talk/review/KCSJWBBRMVCCJ9SVMHXPSZTBBUD3VXBL)       | [https://www.youtube.com/watch?v=Hz9IMJuW5hU](https://www.youtube.com/watch?v=Hz9IMJuW5hU)       |
-| Tuesday July 20   | [DataFrames.jl 1.2 tutorial](https://pretalx.com/juliacon2021/talk/review/9V73MD8VZGHPPFKR993SBKLJHKQTBWY9)        | [https://www.youtube.com/watch?v=tJf24gfcSto](https://www.youtube.com/watch?v=tJf24gfcSto)        |
-| Wednesday July 21      | [Quantum Computing with Julia](https://pretalx.com/juliacon2021/talk/review/JTBPVMHMGTSYAC8W8B87GCXEFXFRVUMW)       | [https://www.youtube.com/watch?v=tEd6driz37w](https://www.youtube.com/watch?v=tEd6driz37w)       |
-| Wednesday July 21   | [Statistics with Julia from the ground up](https://pretalx.com/juliacon2021/talk/review/BWEXCHLMJSSUL8XDHGWUHHKXM9QNUZZQ)        | [https://www.youtube.com/watch?v=IlPoU5Yr2QI](https://www.youtube.com/watch?v=IlPoU5Yr2QI)        |
-| Thursday July 22      | [A mathematical look at electronic structure theory](https://pretalx.com/juliacon2021/talk/review/E8JL8LNM8GALVY3VNQSTNQN7NLREMXVE)       | [https://www.youtube.com/watch?v=HvpPMWVm8aw](https://www.youtube.com/watch?v=HvpPMWVm8aw)       |
-| Thursday July 22  | [Game development in Julia with GameZero.jl](https://pretalx.com/juliacon2021/talk/review/S3MDHHXQ8P9LDMRYRXCMFDDXLLESURNN)        | [https://www.youtube.com/watch?v=ar7wCVlncKE](https://www.youtube.com/watch?v=ar7wCVlncKE)        |
-| Friday July 23     | [Solving differential equations in parallel on GPUs](https://pretalx.com/juliacon2021/talk/review/NDHRHLYN7JZUV88PLFWPL99P93NQVU8K)       | [https://www.youtube.com/watch?v=DvlM0w6lYEY](https://www.youtube.com/watch?v=DvlM0w6lYEY)       |
-| Friday July 23  | [Package development in VSCode](https://pretalx.com/juliacon2021/talk/review/3LTRK3ZEECUVL7TDLGE7UHYHHKNG9DHD)        | [https://www.youtube.com/watch?v=F1R3ETaRQXY](https://www.youtube.com/watch?v=F1R3ETaRQXY)        |
-| Saturday July 24     | [Simulating Big Models in Julia with ModelingToolkit](https://pretalx.com/juliacon2021/talk/review/7YHJAA37XGAQ7GXVBK37JFETTZ3ZLKLU)     | [https://www.youtube.com/watch?v=HEVOgSLBzWA](https://www.youtube.com/watch?v=HEVOgSLBzWA)       |
-| Saturday July 24  | [Package development: improving engineering quality & latency](https://pretalx.com/juliacon2021/talk/review/HFFUMRJE8RGQPWZS9QRTVE9NEWCUMH3N)       | [https://www.youtube.com/watch?v=wXRMwJdEjX4](https://www.youtube.com/watch?v=wXRMwJdEjX4)        |
-| Sunday July 25     | [Parse and broker (log) messages with CombinedParsers(.EBNF)](https://pretalx.com/juliacon2021/talk/review/HWRUWKWRXRZZXCVBS9LVLJPKYL9UYAKS)      | [https://www.youtube.com/watch?v=RpCnP-S7txI](https://www.youtube.com/watch?v=RpCnP-S7txI)       |
-| Sunday July 25  | [Modeling Marine Ecosystems At Multiple Scales Using Julia](https://pretalx.com/juliacon2021/talk/review/MY7U88E7NK8RWACPGA3YEFHKK7DDHKA8)      | [https://www.youtube.com/watch?v=UCIRrXz2ZS0](https://www.youtube.com/watch?v=UCIRrXz2ZS0)        |
-| Monday July 26     | [It's all Set: A hands-on introduction to JuliaReach](https://pretalx.com/juliacon2021/talk/review/9NYAYYMTPVFA9C7N3GUYFJ3C8YHPRSXA)     | [https://www.youtube.com/watch?v=P4I7pTvQ4nk](https://www.youtube.com/watch?v=P4I7pTvQ4nk)       |
-| Monday July 26  | [Introduction to Bayesian Data Analysis](https://pretalx.com/juliacon2021/talk/review/JBAB83AUDTS8VMGRJQXBY9C9AJMANSGU)     | [https://www.youtube.com/watch?v=W_ExvidyESg](https://www.youtube.com/watch?v=W_ExvidyESg)        |
-| Tuesday July 27     | [Diffractor: Next-Gen AD for Julia](https://pretalx.com/juliacon2021/talk/review/MJ7T9LXLXNDWHPW9WJN7SGTWU7L9QMJW)      | [https://www.youtube.com/watch?v=XuTzJCvE62M](https://www.youtube.com/watch?v=XuTzJCvE62M)       |
-| Tuesday July 27  | [Introduction to metaprogramming in Julia](https://pretalx.com/juliacon2021/talk/review/ZEPFHE8Z3QWER8FWHQ8RTE3X7WA9VGXH)      | [https://www.youtube.com/watch?v=2QLhw6LVaq0](https://www.youtube.com/watch?v=2QLhw6LVaq0)        |
-@@
+~~~
+<table class="table table-bordered">
+    <thead>
+    <tr>
+        <th>Date</th>
+        <th>Workshop Title</th>
+        <th>Link</th>
+    </tr>
+    </thead>
+    <tbody>
+
+    <tr>
+        <td>Tuesday July 20</td>
+        <td>
+        <a
+            href="https://pretalx.com/juliacon2021/talk/review/KCSJWBBRMVCCJ9SVMHXPSZTBBUD3VXBL"
+            >GPU programming in Julia</a
+        >
+        </td>
+        <td>
+        <a href="https://www.youtube.com/watch?v=Hz9IMJuW5hU"
+            >https://www.youtube.com/watch?v=Hz9IMJuW5hU</a
+        >
+        </td>
+    </tr>
+    <tr>
+        <td>Tuesday July 20</td>
+        <td>
+        <a
+            href="https://pretalx.com/juliacon2021/talk/review/9V73MD8VZGHPPFKR993SBKLJHKQTBWY9"
+            >DataFrames.jl 1.2 tutorial</a
+        >
+        </td>
+        <td>
+        <a href="https://www.youtube.com/watch?v=tJf24gfcSto"
+            >https://www.youtube.com/watch?v=tJf24gfcSto</a
+        >
+        </td>
+    </tr>
+    <tr>
+        <td>Wednesday July 21</td>
+        <td>
+        <a
+            href="https://pretalx.com/juliacon2021/talk/review/JTBPVMHMGTSYAC8W8B87GCXEFXFRVUMW"
+            >Quantum Computing with Julia</a
+        >
+        </td>
+        <td>
+        <a href="https://www.youtube.com/watch?v=tEd6driz37w"
+            >https://www.youtube.com/watch?v=tEd6driz37w</a
+        >
+        </td>
+    </tr>
+    <tr>
+        <td>Wednesday July 21</td>
+        <td>
+        <a
+            href="https://pretalx.com/juliacon2021/talk/review/BWEXCHLMJSSUL8XDHGWUHHKXM9QNUZZQ"
+            >Statistics with Julia from the ground up</a
+        >
+        </td>
+        <td>
+        <a href="https://www.youtube.com/watch?v=IlPoU5Yr2QI"
+            >https://www.youtube.com/watch?v=IlPoU5Yr2QI</a
+        >
+        </td>
+    </tr>
+    <tr>
+        <td>Thursday July 22</td>
+        <td>
+        <a
+            href="https://pretalx.com/juliacon2021/talk/review/E8JL8LNM8GALVY3VNQSTNQN7NLREMXVE"
+            >A mathematical look at electronic structure theory</a
+        >
+        </td>
+        <td>
+        <a href="https://www.youtube.com/watch?v=HvpPMWVm8aw"
+            >https://www.youtube.com/watch?v=HvpPMWVm8aw</a
+        >
+        </td>
+    </tr>
+    <tr>
+        <td>Thursday July 22</td>
+        <td>
+        <a
+            href="https://pretalx.com/juliacon2021/talk/review/S3MDHHXQ8P9LDMRYRXCMFDDXLLESURNN"
+            >Game development in Julia with GameZero.jl</a
+        >
+        </td>
+        <td>
+        <a href="https://www.youtube.com/watch?v=ar7wCVlncKE"
+            >https://www.youtube.com/watch?v=ar7wCVlncKE</a
+        >
+        </td>
+    </tr>
+    <tr>
+        <td>Friday July 23</td>
+        <td>
+        <a
+            href="https://pretalx.com/juliacon2021/talk/review/NDHRHLYN7JZUV88PLFWPL99P93NQVU8K"
+            >Solving differential equations in parallel on GPUs</a
+        >
+        </td>
+        <td>
+        <a href="https://www.youtube.com/watch?v=DvlM0w6lYEY"
+            >https://www.youtube.com/watch?v=DvlM0w6lYEY</a
+        >
+        </td>
+    </tr>
+    <tr>
+        <td>Friday July 23</td>
+        <td>
+        <a
+            href="https://pretalx.com/juliacon2021/talk/review/3LTRK3ZEECUVL7TDLGE7UHYHHKNG9DHD"
+            >Package development in VSCode</a
+        >
+        </td>
+        <td>
+        <a href="https://www.youtube.com/watch?v=F1R3ETaRQXY"
+            >https://www.youtube.com/watch?v=F1R3ETaRQXY</a
+        >
+        </td>
+    </tr>
+    <tr>
+        <td>Saturday July 24</td>
+        <td>
+        <a
+            href="https://pretalx.com/juliacon2021/talk/review/7YHJAA37XGAQ7GXVBK37JFETTZ3ZLKLU"
+            >Simulating Big Models in Julia with ModelingToolkit</a
+        >
+        </td>
+        <td>
+        <a href="https://www.youtube.com/watch?v=HEVOgSLBzWA"
+            >https://www.youtube.com/watch?v=HEVOgSLBzWA</a
+        >
+        </td>
+    </tr>
+    <tr>
+        <td>Saturday July 24</td>
+        <td>
+        <a
+            href="https://pretalx.com/juliacon2021/talk/review/HFFUMRJE8RGQPWZS9QRTVE9NEWCUMH3N"
+            >Package development: improving engineering quality &amp;
+            latency</a
+        >
+        </td>
+        <td>
+        <a href="https://www.youtube.com/watch?v=wXRMwJdEjX4"
+            >https://www.youtube.com/watch?v=wXRMwJdEjX4</a
+        >
+        </td>
+    </tr>
+    <tr>
+        <td>Sunday July 25</td>
+        <td>
+        <a
+            href="https://pretalx.com/juliacon2021/talk/review/HWRUWKWRXRZZXCVBS9LVLJPKYL9UYAKS"
+            >Parse and broker (log) messages with CombinedParsers(.EBNF)</a
+        >
+        </td>
+        <td>
+        <a href="https://www.youtube.com/watch?v=RpCnP-S7txI"
+            >https://www.youtube.com/watch?v=RpCnP-S7txI</a
+        >
+        </td>
+    </tr>
+    <tr>
+        <td>Sunday July 25</td>
+        <td>
+        <a
+            href="https://pretalx.com/juliacon2021/talk/review/MY7U88E7NK8RWACPGA3YEFHKK7DDHKA8"
+            >Modeling Marine Ecosystems At Multiple Scales Using Julia</a
+        >
+        </td>
+        <td>
+        <a href="https://www.youtube.com/watch?v=UCIRrXz2ZS0"
+            >https://www.youtube.com/watch?v=UCIRrXz2ZS0</a
+        >
+        </td>
+    </tr>
+    <tr>
+        <td>Monday July 26</td>
+        <td>
+        <a
+            href="https://pretalx.com/juliacon2021/talk/review/9NYAYYMTPVFA9C7N3GUYFJ3C8YHPRSXA"
+            >It's all Set: A hands-on introduction to JuliaReach</a
+        >
+        </td>
+        <td>
+        <a href="https://www.youtube.com/watch?v=P4I7pTvQ4nk"
+            >https://www.youtube.com/watch?v=P4I7pTvQ4nk</a
+        >
+        </td>
+    </tr>
+    <tr>
+        <td>Monday July 26</td>
+        <td>
+        <a
+            href="https://pretalx.com/juliacon2021/talk/review/JBAB83AUDTS8VMGRJQXBY9C9AJMANSGU"
+            >Introduction to Bayesian Data Analysis</a
+        >
+        </td>
+        <td>
+        <a href="https://www.youtube.com/watch?v=W_ExvidyESg"
+            >https://www.youtube.com/watch?v=W_ExvidyESg</a
+        >
+        </td>
+    </tr>
+    <tr>
+        <td>Tuesday July 27</td>
+        <td>
+        <a
+            href="https://pretalx.com/juliacon2021/talk/review/MJ7T9LXLXNDWHPW9WJN7SGTWU7L9QMJW"
+            >Diffractor: Next-Gen AD for Julia</a
+        >
+        </td>
+        <td>
+        <a href="https://www.youtube.com/watch?v=XuTzJCvE62M"
+            >https://www.youtube.com/watch?v=XuTzJCvE62M</a
+        >
+        </td>
+    </tr>
+    <tr>
+        <td>Tuesday July 27</td>
+        <td>
+        <a
+            href="https://pretalx.com/juliacon2021/talk/review/ZEPFHE8Z3QWER8FWHQ8RTE3X7WA9VGXH"
+            >Introduction to metaprogramming in Julia</a
+        >
+        </td>
+        <td>
+        <a href="https://www.youtube.com/watch?v=2QLhw6LVaq0"
+            >https://www.youtube.com/watch?v=2QLhw6LVaq0</a
+        >
+        </td>
+    </tr>
+    </tbody>
+</table>
+~~~
 
 ~~~
 <img src="/assets/2021/img/poster-workshops.png" alt="Poster for the JuliaCon 2021 workshop schedule" width="100%" height="400">


### PR DESCRIPTION
Replaced the markdown table with an HTML table to be able to add Bootstrap utility classes more easily and added borders (relates to https://github.com/JuliaCon/www.juliacon.org/issues/279).
![image](https://user-images.githubusercontent.com/6108349/126079194-1e839b32-a2ac-4ae3-8f85-007a0e3cbdb6.png)
