### PR TITLE
Add schedule to top menu.

### DIFF
--- a/_layout/nav.html
+++ b/_layout/nav.html
@@ -14,10 +14,7 @@
             <a class="nav-link" href="/2022/tickets/">Register</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="https://discourse.julialang.org/t/juliacon-2022-t-shirts-socks-stickers-more-now-available/83184">Buy Merch</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/2022/sponsor/">Sponsor</a>
+            <a class="nav-link" href="https://live.juliacon.org/agenda/">Schedule</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="/2022/upload">Upload</a>


### PR DESCRIPTION
remove sponsors (no need any more close to the event) and merch (there is already a top alert link). If needed merchandise info should go in as a content box in the site body. 