### PR TITLE
Terminate grid div in posters.md

### DIFF
--- a/2022/posters.md
+++ b/2022/posters.md
@@ -1,6 +1,6 @@
 # Posters
 
-The JuliaCon 2022 posters will be presented as part of a poster session which will happen synchronously on: July 27th, 2022, from 20:30–22:00 UTC. You can find a calendar invite for the session here: [JuliaCon Poster Session on Pretalx]([https://pretalx.com/juliacon2021/talk/NBER8M/](https://pretalx.com/juliacon-2022/schedule/#2022-07-27))
+The JuliaCon 2022 posters will be presented as part of a poster session which will happen synchronously on: July 27th, 2022, from 20:30–22:00 UTC. You can find a calendar invite for the session here: [JuliaCon Poster Session on Pretalx](https://pretalx.com/juliacon-2022/talk/M7JDGG/)
 
 07-27, 20:30–22:00 (UTC), Green
 

--- a/2022/posters.md
+++ b/2022/posters.md
@@ -36,3 +36,5 @@ The following posters will be presented at JuliaCon2022:
 
 [Mark Kittisopikul](https://twitter.com/markkitti)
 @@
+
+@@

--- a/2022/posters.md
+++ b/2022/posters.md
@@ -32,9 +32,219 @@ The following posters will be presented at JuliaCon2022:
 @@grid
 
 @@poster
-[UInt12Arrays.jl](https://pretalx.com/juliacon-2022/talk/review/T7EKYK7AGEPNWTGCMHQZEL3PSV99LMP9)
+	(Pareto-)Optimal Packages
 
-[Mark Kittisopikul](https://twitter.com/markkitti)
+	Jeremiah Lewis
+@@
+
+
+@@poster
+	A Gradient Enhanced Kriging With Partial Least Squares (GEKPLS)
+
+	Vikram Narayan
+@@
+
+
+@@poster
+	Acelerando un algoritmo de transformación unitaria con Julia
+
+	Alejandro R. Urzúa
+@@
+
+
+@@poster
+	AdvancedPS.jl: Sequential Monte Carlo in Julia
+
+	Frederic Wantiez
+@@
+
+
+@@poster
+	Billion \$\$ toilet paper
+
+	Amit Shukla
+@@
+
+
+@@poster
+	BondGraphs.jl: Composable modelling of thermodynamic networks
+
+	Joshua Forrest
+@@
+
+
+@@poster
+	ComputerAdaptiveTesting.jl: Fast and flexible CATs with Julia
+
+	Frankie Robertson
+@@
+
+
+@@poster
+	Easy comparison of custom structs with StructEquality.jl
+
+	Stephan Sahm
+@@
+
+
+@@poster
+	First steps toward Julia for fluid turbulence simulation
+
+	Nguyen Quang Chien
+@@
+
+
+@@poster
+	Flexpart.jl, a Lagrangian atmospheric dispersion model in Julia
+
+	Tristan Carion
+@@
+
+
+@@poster
+	Fun Insight with Julia DataFrame
+
+	Sorratat Sirirattanajakarin
+@@
+
+
+@@poster
+	J-SPACE: SPAtial Cancer Evolution and sequencing simulator
+
+	Gianluca Ascolani
+@@
+
+
+@@poster
+	Julia in ASEAN
+
+	Bishmer Sekaran
+@@
+
+
+@@poster
+	Large-Scale Satellite Imagery Processing with BanyanImages.jl
+
+	Caleb Winston, Cailin Winston
+@@
+
+
+@@poster
+	Mapping Magnetic Susceptibility of MRIs in Julia
+
+	Christian Kames
+@@
+
+
+@@poster
+	Massively Distributed Oceanangians.jl with Banyan.jl
+
+	Caleb Winston, Cailin Winston
+@@
+
+
+@@poster
+	Massively Parallel Parameter Tuning with BanyanArrays.jl
+
+	Caleb Winston, Cailin Winston
+@@
+
+
+@@poster
+	Multilinear maps and fluid mechanics with Julia
+
+	Nicholas Chisholm
+@@
+
+
+@@poster
+	Nautilus.jl - a GUI for interactive compiler optimization passes
+
+	Miguel Raz Guzmán Macedo
+@@
+
+
+@@poster
+	Non-linear SDE mechanical simulations
+
+	Gillot
+@@
+
+
+@@poster
+	Phylogenetic trees in Julia
+
+	Gustavo A. Ballen
+@@
+
+
+@@poster
+	Psychosis and NLP with Julia: the TextGraphs.jl package
+
+	Felipe Coelho Argolo
+@@
+
+
+@@poster
+	Recovery of Parameters in Sea Ice Modeling using UDEs
+
+	Eric Brown
+@@
+
+
+@@poster
+	Remote Sensing in Julia: an absolute beginner's perspective
+
+	António Almeida
+@@
+
+
+@@poster
+	RobertoMD: Parallel Hybrid Particle-Field Molecular Simulation
+
+	Zhenghao Wu, S. Alberti
+@@
+
+
+@@poster
+	Role of Julia in the Blockchain and Web 3.0 Ecosystem
+
+	Dr. Vikas Negi
+@@
+
+
+@@poster
+	Trajectory Estimation in MRI with Julia
+
+	Alexander Jaffray
+@@
+
+
+@@poster
+	UInt12Arrays and types that are not a multiple of a byte
+
+	Mark Kittisopikul, Ph.D.
+@@
+
+
+@@poster
+	Using Julia to solve the college application problem
+
+	Max Kapur
+@@
+
+
+@@poster
+	ValSplit.jl: Fast & extensible switch statements via Val-types
+
+	Xuan (Tan Zhi Xuan)
+@@
+
+
+@@poster
+	Why you should be teaching your students to program in Julia
+
+	Logan Kilpatrick
 @@
 
 @@


### PR DESCRIPTION
1) Fixes posters by closing the div so it will appear again.
2) Adds poster presentations without links since I do not have access to the link information.