### PR TITLE
[Improvement] Enhancing Navbar and Title Rendering for JuliaCon Events

### DIFF
--- a/2020/index.md
+++ b/2020/index.md
@@ -2,10 +2,12 @@
 title = "JuliaCon 2020, Everywhere on Earth"
 
 # top title + subtitle
+insert_title_year = true
 top_title = "Juliacon 2020 was live and online"
 top_date = "Wednesday 29th to Friday 31st of July, 2020"
 top_subtitle = "(Workshops: 24th to 28th July)"
 top_link = "https://live.juliacon.org/agenda/2020-07-25"
+top_title_heading = "../assets/2020/img/world_768.png 768w, ../assets/2020/img/world_1400.png 1400w, ../assets/2020/img/world_2800.png 2800w"
 +++
 
 ~~~

--- a/2021/index.md
+++ b/2021/index.md
@@ -2,9 +2,11 @@
 title = "JuliaCon 2021 & JuMP-dev, Everywhere on Earth"
 
 # top title + subtitle
+insert_title_year = true
 top_title = "Juliacon 2021 (with JuMP-dev) was online and virtual"
 top_date = "28th to 30th of July, 2021"
 top_subtitle = "check out all the recorded talks on YouTube"
+top_title_heading = "../assets/2021/img/world_768.png 768w, ../assets/2021/img/world_1400.png 1400w, ../assets/2021/img/world_2800.png 2800w"
 +++
 
 ~~~

--- a/2022/index.md
+++ b/2022/index.md
@@ -2,9 +2,11 @@
 title = "JuliaCon 2022, Everywhere on Earth"
 
 # top title + subtitle
+insert_title_year = true
 top_title = "JuliaCon 2022 was online and the recorded talks are available on YouTube"
 top_date = "July 27th - 29th - Times in UTC \n"
 top_subtitle = "Tickets were free but registration was required"
+top_title_heading = "../assets/2021/img/world_768.png 768w, ../assets/2021/img/world_1400.png 1400w, ../assets/2021/img/world_2800.png 2800w"
 +++
 
 ~~~

--- a/2023/index.md
+++ b/2023/index.md
@@ -2,9 +2,11 @@
 title = "JuliaCon 2023"
 
 # top title + subtitle
+insert_title_year = true
 top_title = "JuliaCon 2023\n"
 top_date = "Cambridge, USA. July 25th - 29th, 2023. \n"
 top_subtitle = "(co-located with JuMP-dev and SciMLCon)"
+top_title_heading = "../assets/2023/img/boston_768.png 768w, ../assets/2023/img/boston_1400.png 1400w, ../assets/2023/img/boston_2800.png 2800w"
 +++
 
 ~~~

--- a/_layout/head.html
+++ b/_layout/head.html
@@ -95,8 +95,10 @@
 
   {{insert nav_year.html}}
 
-  {{ispage /2023/index.html /2022/index.html /2021/index.html /2020/index.html}}
-    {{insert title_year.html}}
+  {{isdef insert_title_year}}
+    {{if insert_title_year}}
+      {{insert title_year.html}}
+    {{end}}
   {{end}}
 
   {{insert nav.html}}

--- a/_layout/nav.html
+++ b/_layout/nav.html
@@ -9,72 +9,7 @@
           <li id="waving-flag">
             <img src="/assets/shared/img/waving-flag.gif" style="position: relative; top: 10pt; height: 64pt; margin-top: -42pt;" alt="">
           </li>
-          {{ispage /2023/*}}
-          <li class="nav-item">
-            <a class="nav-link" href="/2023/volunteer">Volunteer</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/2023/tickets">Tickets</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="https://pretalx.com/juliacon2023/schedule/">Full Schedule</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/2023/sponsor">Sponsor</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/2023/upload">Upload</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/2023/coc/">Code of Conduct</a>
-          </li>
-          {{end}}
-          {{ispage /2022/*}}
-          <li class="nav-item">
-            <a class="nav-link" href="/2022/tickets/">Register</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="https://pretalx.com/juliacon-2022/schedule/">Full Schedule</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="https://live.juliacon.org/agenda/">Watch Live</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/2022/volunteer">Volunteer</a>
-          </li>
-          <!-- <li class="nav-item">
-            <a class="nav-link" href="/2022/upload">Upload</a>
-          </li> -->
-          <li class="nav-item">
-            <a class="nav-link" href="/2022/meetups/">Local Meetups</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/2022/coc/">Code of Conduct</a>
-          </li>
-          {{end}}
-          {{ispage /2020/*}}
-          <li class="nav-item">
-            <a class="nav-link" href="/2020/sponsor/">Sponsor</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/2020/tickets/">Register</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="https://live.juliacon.org">Live Schedule!</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/2020/volunteer/">Volunteer</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/2020/accessibility/">Accessibility</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/2020/faq/">FAQ</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/2020/upload/">Upload</a>
-          </li>
-          {{end}}
+          {{navbar}}
           <li class="nav-item">
             <a class="nav-link" href="https://proceedings.juliacon.org/">Proceedings</a>
           </li>

--- a/_layout/title_year.html
+++ b/_layout/title_year.html
@@ -12,34 +12,7 @@
   </div>
 </div>
 
-{{ispage /2020/*}}
-<img class="heading-hero" alt=""
-  srcset="../assets/2020/img/world_768.png 768w, ../assets/2020/img/world_1400.png 1400w, ../assets/2020/img/world_2800.png 2800w"
-  sizes="100vw"
-/>
-{{end}}
-
-{{ispage /2021/*}}
-
-<img class="heading-hero" alt=""
-  srcset="../assets/2021/img/world_768.png 768w, ../assets/2021/img/world_1400.png 1400w, ../assets/2021/img/world_2800.png 2800w"
-  sizes="100vw"
-/>
-{{end}}
-
-{{ispage /2022/*}}
-
-<img class="heading-hero" alt=""
-  srcset="../assets/2021/img/world_768.png 768w, ../assets/2021/img/world_1400.png 1400w, ../assets/2021/img/world_2800.png 2800w"
-  sizes="100vw"
-/>
-{{end}}
-
-{{ispage /2023/*}}
-
-<img class="heading-hero" style="z-index:-1" alt="boston skyline"
- srcset="../assets/2023/img/boston_768.png 768w, ../assets/2023/img/boston_1400.png 1400w, ../assets/2023/img/boston_2800.png 2800w"
-  sizes="100vw"
-/>
+{{isdef top_title_heading}}
+  <img class="heading-hero" srcset="{{ top_title_heading }}" sizes="100vw"/>
 {{end}}
 

--- a/config.md
+++ b/config.md
@@ -17,6 +17,12 @@ content_tag = ""
 
 keep_path = ["2019/", "2018/", "2017/", "2016/", "2015/", "2014/"]
 
+header = Dict(
+    "2020" => [ "Sponsor" => "/2020/sponsor", "Register" => "/2020/tickets", "Live Schedule!" => "https://live.juliacon.org", "Volunteer" => "/2020/volunteer", "Accessibility" => "/2020/accessibility", "FAQ" => "/2020/faq", "Upload" => "/2020/upload" ],
+    "2021" => [ "Sponsor" => "/2021/sponsor", "Register" => "/2021/tickets", "Live Schedule!" => "https://live.juliacon.org", "Volunteer" => "/2021/volunteer", "Accessibility" => "/2021/accessibility", "FAQ" => "/2021/faq", "Upload" => "/2021/upload" ],
+    "2022" => [ "Register" => "/2022/tickets/", "Full Schedule" => "https://pretalx.com/juliacon-2022/schedule/", "Watch Live" => "https://live.juliacon.org/agenda/", "Volunteer" => "/2022/volunteer", "Local Meetups" => "/2022/meetups", "Code of Conduct" => "/2022/coc" ],
+    "2023" => [ "Volunteer" => "/2023/volunteer", "Tickets" => "/2023/tickets", "Full Schedule" => "https://pretalx.com/juliacon2023/schedule/", "Sponsor" => "/2023/sponsor", "Upload" => "/2023/upload", "Code of Conduct" => "/2023/coc" ],
+)
 +++
 
 \newcommand{\vskip}{@@u-vskip-3 @@}

--- a/utils.jl
+++ b/utils.jl
@@ -32,26 +32,70 @@ end
 
 # NAV_YEAR tools
 
-curyear() = parse(Int, match(r"^[\/|\\]?(20\d{2})[\/||\\]", locvar(:fd_rpath)::String).captures[1])
+configyear() = parse(Int, locvar(:year)::String)
+function curyear() 
+  m = match(r"^[\/|\\]?(20\d{2})[\/||\\]", locvar(:fd_rpath)::String)
+  # fallback in case if the link does not have a year in it
+  # may happen for local juliacons
+  if !isnothing(m) && !isempty(m.captures)
+    return parse(Int, m.captures[1])
+  else
+    return configyear()
+  end
+end
 
 function hfun_curyear()
     return "$(curyear())"
 end
 
 function hfun_previous_editions()
+    config_year = configyear()
     year = curyear()
-    pre_years = year-1:-1:2014
-    io = IOBuffer()
-    for (i, y) in enumerate(pre_years)
-        write(io, """<a href="/$y/">$y</a>""")
-        i == length(pre_years) || write(io, "/")
+   
+    post_years = config_year:-1:(year + 1)
+    io_post = IOBuffer()
+    for (i, y) in enumerate(post_years)
+      write(io_post, """<a href="/$y/">$y</a>""")
+      i == length(post_years) || write(io_post, "/")
     end
-    prevs = String(take!(io))
+
+    pre_years = (year - 1):-1:2014
+    io_prev = IOBuffer()
+    for (i, y) in enumerate(pre_years)
+        write(io_prev, """<a href="/$y/">$y</a>""")
+        i == length(pre_years) || write(io_prev, "/")
+    end
+
+    post = String(take!(io_post))
+    prev = String(take!(io_prev))
+
+    html_post = ifelse(!isempty(post), """<span style="padding-left: 10px">Future: $post</span>""", "")
+    html_prev = ifelse(!isempty(prev), """<span style="padding-left: 10px">Previously: $prev</span>""", "")
+
     return """
         <div class="u-futura u-uppercase previous-editions-menu" style="margin:auto">
-          Previously: $prevs
+          $html_post
+          $html_prev
         </div>
         """
+end
+
+function hfun_navbar()
+  io = IOBuffer()
+  header = locvar(:header)
+  entries = keys(header)
+  rpath = locvar(:fd_rpath)::String
+
+  for (prefix, entries) in pairs(header)
+    if startswith(rpath, prefix)
+      for (title, link) in entries 
+        write(io, """<li class="nav-item"><a class="nav-link" href="$link">$title</a></li>""")
+      end
+    end
+  end
+
+  html = String(take!(io))
+  return html
 end
 
 @env function centered(md; title="Title", margin_bottom="auto")


### PR DESCRIPTION
This PR improves a little bit the way the website renders the navbar and the title.

The current implementation presents difficulties when modifying the navbar for different events (e.g. future global JuliaCon or local JuliaCon events). With this PR, integrating new events into the main JuliaCon website becomes more manageable.

Previously, the HTML code relied on multiple `if else` statements for each year, which is not scalable for future JuliaCon and JuliaCon Local events. This PR addresses this issue by refactoring the code and introducing a new variable, `header`, in the `config.md` file. The rendering of the `header` itself is then handled by the `hfun_navbar` function defined in `utils.jl`. Additionally, two new functions, `insert_title_year` and `top_title_heading`, have been defined. The former determines whether the large title with images should be displayed, while the latter defines the banner image.

This PR only addresses Franklin based years from 2020 to 2023.

Minor Improvement:

Furthermore, I have made an addition to the header by including "Future" JuliaCons. For example, if you refer to the old JuliaCon 2020 page, the previous implementation displayed an image as follows:

Before:
<img width="558" alt="image" src="https://github.com/JuliaCon/www.juliacon.org/assets/6557701/48b2692d-ffe6-4cdc-9684-f873a92420ea">

With this PR, the html code has been updated to the following:

<img width="754" alt="image" src="https://github.com/JuliaCon/www.juliacon.org/assets/6557701/32e237cc-a595-4881-a520-fb64e67b50a6">

@matthijscox  @el-oso