### PR TITLE
Remove more if statements in html from the webiste

### DIFF
--- a/_layout/head.html
+++ b/_layout/head.html
@@ -8,7 +8,7 @@
 
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:site" content="@JuliaConOrg" />
-  <meta name="twitter:image" content="https://juliacon.org/assets/JuliaCon-2023-opengraph.png" />
+  <meta name="twitter:image" content="{{ site_thumbnail }}" />
 
   <meta property="og:site_name" content="{{site_name}}" />
   <meta property="og:type" content="website" />
@@ -17,11 +17,8 @@
   <meta property="og:url" content="{{site_url}}" />
 
 
-  <meta property="og:image" content="https://juliacon.org/assets/JuliaCon-2023-opengraph.png" />
+  <meta property="og:image" content="{{ site_thumbnail }}" />
   <meta property="og:image:type" content="image/png" />
-  <meta property="og:image:width" content="2800" />
-  <meta property="og:image:height" content="860" />
-
 
   <!-- Favicon + title -->
   <link rel="icon" href="/assets/favicon.png">
@@ -35,33 +32,10 @@
   <link rel="stylesheet" href="/css/bootstrap.min.css">
   <link rel="stylesheet" href="/css/style.css">
 
-  {{ispage /2023/*}}
   <style>
-    .main-heading h2 { color: black; }
-    .main-menu { background-color: #389826}
+    .main-heading h2 { color: {{ main_heading_color }}; }
+    .main-menu { background-color: {{ navbar_color }}; }
   </style>
-  {{end}}
-
-  {{ispage /2022/*}}
-  <style>
-    .main-heading h2 { color: black; }
-    .main-menu { background-color: #389826}
-  </style>
-  {{end}}
-
-  {{ispage /2021/*}}
-  <style>
-    .main-heading h2 { color: black; }
-    .main-menu { background-color: #389826}
-  </style>
-  {{end}}
-
-  {{ispage /2020/*}}
-  <style>
-    .main-heading h2 { color: #4366d0; }
-    .main-menu { background-color: #9558b2}
-  </style>
-  {{end}}
 
   <!-- misc scripts -->
   <script src="https://use.typekit.net/orl3mkt.js"></script>
@@ -76,18 +50,7 @@
   <div class="container-fluid earlybird">
     <div class="container">
       <div class="alert">
-        {{ispage /2020/*}}
-          Check out the JuliaCon 2020 <a href="https://www.youtube.com/playlist?list=PLP8iPy9hna6Tl2UHTrm4jnIYrLkIcAROR">videos</a>
-        {{end}}
-        {{ispage /2021/*}}
-         <a href="/2021/prize/">Community Prize</a> | <a href="https://live.juliacon.org">Watch the talks</a> | <a href="https://discourse.julialang.org/t/juliacon-2021-t-shirts-and-stickers-on-sale-now/62060">Order a JuliaCon T-shirt</a> 
-        {{end}}
-        {{ispage /2022/*}}
-         <a href="https://www.youtube.com/playlist?list=PLP8iPy9hna6TRg6qJaBLJ-FRMi9Cp7gSX">Watch the recorded JuliaCon 2022 talks!</a>
-        {{end}}
-        {{ispage /2023/*}}
-         <a href="https://live.juliacon.org">Online attendees, follow the live stream here!</a>
-        {{end}}
+        {{ alert_text }}
       </div>
     </div>
   </div>

--- a/config.md
+++ b/config.md
@@ -40,7 +40,7 @@ configuration = Dict(
         ]
     ),
     "2021" => Dict(
-        "alert" => """<a href="/2021/prize/">Community Prize</a> | <a href="https://live.juliacon.org">Watch the talks</a> | <a href="https://discourse.julialang.org/t/juliacon-2021-t-shirts-and-stickers-on-sale-now/62060">Order a JuliaCon T-shirt</a>""",
+        "alert" => """Check out the JuliaCon 2021 <a href="https://www.youtube.com/playlist?list=PLP8iPy9hna6Q343_8sSq4f306VGLW4TLK"videos</a> | <a href="/2021/prize/">Community Prize</a>""",
         "site_name" => "JuliaCon 2021",
         "site_descr" => "JuliaCon 2021",
         "site_url" => "https://juliacon.org/2021/",
@@ -77,7 +77,6 @@ configuration = Dict(
         "site_name" => "JuliaCon 2023",
         "site_descr" => "JuliaCon 2023, MIT, Cambridge",
         "site_url" => "https://juliacon.org/2023/",
-        "site_thumbnail" => "../assets/JuliaCon-2023-opengraph.png",
         "main_heading_color" => "black",
         "header_color" => "#389826",
         "header" => [

--- a/config.md
+++ b/config.md
@@ -3,12 +3,8 @@ author = "JuliaCon"
 
 prepath = ""        # remove this when deploying
 
-# Used for the metadata (open graph)
-year       = "2023"
-location   = "MIT, Cambridge"
-site_name  = "JuliaCon $year"
-site_descr = "JuliaCon $year, $location"
-site_url   = "https://juliacon.org/$year/"
+# Current year
+year = "2023"
 
 generate_rss = false
 mintoclevel = 2
@@ -17,59 +13,106 @@ content_tag = ""
 
 keep_path = ["2019/", "2018/", "2017/", "2016/", "2015/", "2014/"]
 
-# Used to generate the links in the navbar for various events
-# Each entry can be either "Link Title"::String => "Link Url"::String
-#                       or "Link Title"::String => "SubMenu"::Vector{Pair{String, String}}
-header = Dict(
-    "2020" => [
-        "Sponsor" => "/2020/sponsor",
-        "Register" => "/2020/tickets",
-        "Live Schedule!" => "https://live.juliacon.org",
-        "Volunteer" => "/2020/volunteer",
-        "Accessibility" => "/2020/accessibility",
-        "FAQ" => "/2020/faq",
-        "Upload" => "/2020/upload"
-    ],
-    "2021" => [
-        "Sponsor" => "/2021/sponsor",
-        "Register" => "/2021/tickets",
-        "Live Schedule!" => "https://live.juliacon.org",
-        "Volunteer" => "/2021/volunteer",
-        "Accessibility" => "/2021/accessibility",
-        "FAQ" => "/2021/faq",
-        "Upload" => "/2021/upload"
-    ],
-    "2022" => [
-        "Register" => "/2022/tickets/",
-        "Full Schedule" => "https://pretalx.com/juliacon-2022/schedule/",
-        "Watch Live" => "https://live.juliacon.org/agenda/",
-        "Volunteer" => "/2022/volunteer",
-        "Local Meetups" => "/2022/meetups",
-        "Code of Conduct" => "/2022/coc"
-    ],
-    "2023" => [
-        "Volunteer" => "/2023/volunteer",
-        "Tickets" => "/2023/tickets",
-        "Full Schedule" => "https://pretalx.com/juliacon2023/schedule/",
-        "Local" => [
-            "Venue" => "/2023/venue",
-            "Food Options" => "/2023/food",
-            "Social Events" => "/2023/social",
-        ],
-        "Posters" => "/2023/posters",
-        "Sponsor" => "/2023/sponsor",
-        "Upload" => "/2023/upload",
-        "Code of Conduct" => "/2023/coc"
-    ],
-    "local/eindhoven2023" => [
-        "Volunteer" => "/local/eindhoven2023/committee",
-        "Tickets" => "/local/eindhoven2023/tickets",
-        "Sponsor" => "/local/eindhoven2023/sponsor",
-        "Venue" => "/local/eindhoven2023/venue",
-        "Program" => "/local/eindhoven2023/program",
-        "Submit your talk" => "/local/eindhoven2023/cfp",
-        "Code of Conduct" => "/local/eindhoven2023/coc"
-    ]
+# Global configuration per event
+# The `alert` displays the message on the top of the website
+# For the `header` each entry can be either "Link Title"::String => "Link Url"::String
+#                                        or "Link Title"::String => "SubMenu"::Vector{Pair{String, String}}
+# Use `header_color` to adjust the color of the `header` for an event.
+# Use `main_heading_color` to adjust the color of the text in the main heading.
+# The `site_name`, `site_descr` and `site_rul` are used in open graph
+# The `site_thumbnail` is used in open graph to show an image in social medias, e.g. twitter or discord
+configuration = Dict(
+    "2020" => Dict(
+        "alert" => """Check out the JuliaCon 2020 <a href="https://www.youtube.com/playlist?list=PLP8iPy9hna6Tl2UHTrm4jnIYrLkIcAROR">videos</a>""",
+        "site_name" => "JuliaCon 2020",
+        "site_descr" => "JuliaCon 2020",
+        "site_url" => "https://juliacon.org/2020/",
+        "main_heading_color" => "#4366d0",
+        "header_color" => "#9558b2",
+        "header" => [
+            "Sponsor" => "/2020/sponsor",
+            "Register" => "/2020/tickets",
+            "Live Schedule!" => "https://live.juliacon.org",
+            "Volunteer" => "/2020/volunteer",
+            "Accessibility" => "/2020/accessibility",
+            "FAQ" => "/2020/faq",
+            "Upload" => "/2020/upload"
+        ]
+    ),
+    "2021" => Dict(
+        "alert" => """<a href="/2021/prize/">Community Prize</a> | <a href="https://live.juliacon.org">Watch the talks</a> | <a href="https://discourse.julialang.org/t/juliacon-2021-t-shirts-and-stickers-on-sale-now/62060">Order a JuliaCon T-shirt</a>""",
+        "site_name" => "JuliaCon 2021",
+        "site_descr" => "JuliaCon 2021",
+        "site_url" => "https://juliacon.org/2021/",
+        "main_heading_color" => "black",
+        "header_color" => "#389826",
+        "header" => [
+            "Sponsor" => "/2021/sponsor",
+            "Register" => "/2021/tickets",
+            "Live Schedule!" => "https://live.juliacon.org",
+            "Volunteer" => "/2021/volunteer",
+            "Accessibility" => "/2021/accessibility",
+            "FAQ" => "/2021/faq",
+            "Upload" => "/2021/upload"
+        ]
+    ),
+    "2022" => Dict(
+        "alert" => """<a href="https://www.youtube.com/playlist?list=PLP8iPy9hna6TRg6qJaBLJ-FRMi9Cp7gSX">Watch the recorded JuliaCon 2022 talks!</a>""",
+        "site_name" => "JuliaCon 2022",
+        "site_descr" => "JuliaCon 2022",
+        "site_url" => "https://juliacon.org/2022/",
+        "main_heading_color" => "black",
+        "header_color" => "#389826",
+        "header" => [
+            "Register" => "/2022/tickets/",
+            "Full Schedule" => "https://pretalx.com/juliacon-2022/schedule/",
+            "Watch Live" => "https://live.juliacon.org/agenda/",
+            "Volunteer" => "/2022/volunteer",
+            "Local Meetups" => "/2022/meetups",
+            "Code of Conduct" => "/2022/coc"
+        ]
+    ),
+    "2023" => Dict(
+        "alert" => """<a href="https://live.juliacon.org">Online attendees, follow the live stream here!</a>""",
+        "site_name" => "JuliaCon 2023",
+        "site_descr" => "JuliaCon 2023, MIT, Cambridge",
+        "site_url" => "https://juliacon.org/2023/",
+        "site_thumbnail" => "../assets/JuliaCon-2023-opengraph.png",
+        "main_heading_color" => "black",
+        "header_color" => "#389826",
+        "header" => [
+            "Volunteer" => "/2023/volunteer",
+            "Tickets" => "/2023/tickets",
+            "Full Schedule" => "https://pretalx.com/juliacon2023/schedule/",
+            "Local" => [
+                "Venue" => "/2023/venue",
+                "Food Options" => "/2023/food",
+                "Social Events" => "/2023/social",
+            ],
+            "Posters" => "/2023/posters",
+            "Sponsor" => "/2023/sponsor",
+            "Upload" => "/2023/upload",
+            "Code of Conduct" => "/2023/coc"
+        ]
+    ),
+    "local/eindhoven2023" => Dict(
+        "alert" => """Submit your talk now for <a href="https://eindhoven2023.pydata.org/juliacon/cfp">JuliaCon Local Eindhoven</a> or <a href="https://eindhoven2023.pydata.org/pydata/cfp">PyData Eindhoven</a>!""",
+        "site_name" => "JuliaCon Local Eindhoven 2023",
+        "site_descr" => "JuliaCon Local Eindhoven 2023, Eindhoven, High Tech Campus",
+        "site_url" => "https://juliacon.org/local/eindhoven2023/",
+        "site_thumbnail" => "../../assets/local/eindhoven2023/img/juliacon_local_eindhoven_logo.png",
+        "main_heading_color" => "3857bd",
+        "header_color" => "#389826",
+        "header" => Dict(
+            "Volunteer" => "/local/eindhoven2023/committee",
+            "Tickets" => "/local/eindhoven2023/tickets",
+            "Sponsor" => "/local/eindhoven2023/sponsor",
+            "Venue" => "/local/eindhoven2023/venue",
+            "Program" => "/local/eindhoven2023/program",
+            "Submit your talk" => "/local/eindhoven2023/cfp",
+            "Code of Conduct" => "/local/eindhoven2023/coc"
+        )
+    )
 )
 +++
 

--- a/config.md
+++ b/config.md
@@ -23,7 +23,7 @@ keep_path = ["2019/", "2018/", "2017/", "2016/", "2015/", "2014/"]
 # The `site_thumbnail` is used in open graph to show an image in social medias, e.g. twitter or discord
 configuration = Dict(
     "2020" => Dict(
-        "alert" => """Check out the JuliaCon 2020 <a href="https://www.youtube.com/playlist?list=PLP8iPy9hna6Tl2UHTrm4jnIYrLkIcAROR">videos</a>""",
+        "alert" => """<a href="https://www.youtube.com/playlist?list=PLP8iPy9hna6Tl2UHTrm4jnIYrLkIcAROR">Check out the JuliaCon 2020 videos</a>""",
         "site_name" => "JuliaCon 2020",
         "site_descr" => "JuliaCon 2020",
         "site_url" => "https://juliacon.org/2020/",
@@ -40,7 +40,7 @@ configuration = Dict(
         ]
     ),
     "2021" => Dict(
-        "alert" => """Check out the JuliaCon 2021 <a href="https://www.youtube.com/playlist?list=PLP8iPy9hna6Q343_8sSq4f306VGLW4TLK"videos</a> | <a href="/2021/prize/">Community Prize</a>""",
+        "alert" => """<a href="https://www.youtube.com/playlist?list=PLP8iPy9hna6Q343_8sSq4f306VGLW4TLK">Check out the JuliaCon 2021 videos</a> | <a href="/2021/prize/">Community Prize</a>""",
         "site_name" => "JuliaCon 2021",
         "site_descr" => "JuliaCon 2021",
         "site_url" => "https://juliacon.org/2021/",
@@ -57,7 +57,7 @@ configuration = Dict(
         ]
     ),
     "2022" => Dict(
-        "alert" => """<a href="https://www.youtube.com/playlist?list=PLP8iPy9hna6TRg6qJaBLJ-FRMi9Cp7gSX">Watch the recorded JuliaCon 2022 talks!</a>""",
+        "alert" => """<a href="https://www.youtube.com/playlist?list=PLP8iPy9hna6TRg6qJaBLJ-FRMi9Cp7gSX">Check out the JuliaCon 2022 videos</a>""",
         "site_name" => "JuliaCon 2022",
         "site_descr" => "JuliaCon 2022",
         "site_url" => "https://juliacon.org/2022/",
@@ -73,7 +73,7 @@ configuration = Dict(
         ]
     ),
     "2023" => Dict(
-        "alert" => """<a href="https://live.juliacon.org">Online attendees, follow the live stream here!</a>""",
+        "alert" => """<a href="https://youtube.com/playlist?list=PLP8iPy9hna6Q5tiN8gX1wMgBGdqRT_ZTE">Check out the JuliaCon 2023 videos</a>""",
         "site_name" => "JuliaCon 2023",
         "site_descr" => "JuliaCon 2023, MIT, Cambridge",
         "site_url" => "https://juliacon.org/2023/",

--- a/utils.jl
+++ b/utils.jl
@@ -80,6 +80,26 @@ function hfun_previous_editions()
         """
 end
 
+function get_from_config(key; default = "")
+  rpath = locvar(:fd_rpath)::String
+  for (prefix, eventconfig) in pairs(locvar(:configuration))
+    if startswith(rpath, prefix) && haskey(eventconfig, key)
+      return eventconfig[key]
+    end
+  end
+  return default
+end
+
+
+# Configuration entries
+hfun_alert_text() = get_from_config("alert"; default = "")
+hfun_main_heading_color() = get_from_config("main_heading_color"; default = "black")
+hfun_navbar_color() = get_from_config("header_color"; default = "#389826")
+hfun_site_name() = get_from_config("site_name"; default = "JuliaCon")
+hfun_site_descr() = get_from_config("site_descr"; default = "JuliaCon")
+hfun_site_url() = get_from_config("site_url"; default = "https://juliacon.org/")
+hfun_site_thumbnail() = get_from_config("site_thumbnail"; default = "../assets/shared/img/JuliaConGitHubPreview.png")
+
 navbar_entry(io, entry::Pair) = navbar_entry(io, entry[1], entry[2])
 
 # Generates a single title -> url entry
@@ -98,13 +118,11 @@ end
 
 function hfun_navbar()
   io = IOBuffer()
-  header = locvar(:header)
-  entries = keys(header)
   rpath = locvar(:fd_rpath)::String
 
-  for (prefix, entries) in pairs(header)
-    if startswith(rpath, prefix)
-      foreach((entry) -> navbar_entry(io, entry), entries)
+  for (prefix, eventconfig) in pairs(locvar(:configuration))
+    if startswith(rpath, prefix) && haskey(eventconfig, "header")
+      foreach((entry) -> navbar_entry(io, entry), eventconfig["header"])
     end
   end
 


### PR DESCRIPTION
This PR removes many if statements from HTML files on the website and moves them in one place under `config.md` file. 
It makes it easier to control everything in one place and adds new extra features that were difficult before. For example, now it is easy to use different OpenGraph images per event. This fixes #414. Now each event can customize their OpenGraph metadata, alert messages on the top of the website, header, header colors, and all of it in one place!

![image](https://github.com/JuliaCon/www.juliacon.org/assets/6557701/5b9896fe-9bd1-41d6-a52a-500e1c85b00f)

@cityjumper