### PR TITLE
Update committee to include Flemming Holtorf

### DIFF
--- a/2023/committee.md
+++ b/2023/committee.md
@@ -12,7 +12,8 @@
 * Steven Kell, Media and Publicity [GitHub](https://github.com/StevenKell)
 * Carsten Bauer, Proceedings Chair [GitHub](https://github.com/carstenbauer)
 * Pablo Zubieta, Web [Github](https://github.com/pabloferz)
-
+* Flemming Holtorf, Accessibility [Github](https://github.com/fholtorf)
+ 
 ## Proceedings Committee
 
 * Carsten Bauer


### PR DESCRIPTION
To acknowledge all of the help to comply with MIT's accessibility requirements and find a partner for subtitling.