### PR TITLE
JuliaCon Local Eindhoven: post event update

### DIFF
--- a/config.md
+++ b/config.md
@@ -115,7 +115,7 @@ configuration = Dict(
         "year" => 2023,
         "advertise_in_landing" => true,
         "location" => "Eindhoven",
-        "alert" => """The <a href="https://juliacon.org/local/eindhoven2023/program/">program</a> is ready! Also, check out our <a href="https://juliacon.org/local/eindhoven2023/pluto/">Pluto workshop</a>!""",
+        "alert" => """Check out the next <a href="https://juliacon.org/2024/">JuliaCon</a>!""",
         "site_name" => "JuliaCon Local Eindhoven 2023",
         "site_descr" => "JuliaCon Local Eindhoven 2023, Eindhoven, High Tech Campus",
         "site_url" => "https://juliacon.org/local/eindhoven2023/",

--- a/local/eindhoven2023/index.md
+++ b/local/eindhoven2023/index.md
@@ -44,15 +44,15 @@ Click [here](/local/eindhoven2023/pluto/) for more information, and don't miss o
 Secure your spot at the Pluto Workshop, where the possibilities are as limitless as the universe itself 🎈
 \end{box}
 
-\begin{box}{title="Tickets", color="dark-green"}
+<!-- \begin{box}{title="Tickets", color="dark-green"}
 
 Don't miss your chance to be at the forefront of the Julia revolution.
 Whether you're a seasoned programmer, a curious beginner, or a visionary researcher, this event offers a golden opportunity to elevate your skills, broaden your horizons, and shape the future of technology. 
 
 [Order your tickets](/local/eindhoven2023/tickets/) today and unlock a world of infinite possibilities with Julia!
-\end{box}
+\end{box} -->
 
-\begin{box}{title="Diversity scholarship", color="dark-blue"}
+\begin{box}{title="Diversity scholarship", color="dark-green"}
 
 For JuliaCon Local Eindhoven 2023, we are offering scholarship opportunities, including networking events with our sponsoring companies, to individuals from underrepresented groups who might otherwise face barriers to attending the conference.
 

--- a/local/eindhoven2023/pluto.md
+++ b/local/eindhoven2023/pluto.md
@@ -19,10 +19,12 @@ The Pluto Workshop will be hosted on **Thursday the 30th of November** with offi
 
 ~~~
 <div style="text-align: center">
-    <a class="btn" style="width: 40%;" href="https://forms.gle/UPJFHNfnDELThw3m9">Signup for the Pluto Workshop</a>
-</div>
-<br>
 ~~~
+> :warning: **The registration is closed**
+~~~
+</div>
+~~~
+
 
 Open Pluto barcamp and hackathon 
 

--- a/local/eindhoven2023/tickets.md
+++ b/local/eindhoven2023/tickets.md
@@ -20,7 +20,11 @@ Welcome to the registration page for JuliaCon 2023! We're thrilled to announce t
 **Note**: Ticket sales for JuliaCon Local Eindhoven 2023 are being managed through a separate website hosted by PyData. To secure your tickets, we use PyData Ticketing Website. This dedicated platform will streamline the registration process and ensure a smooth experience for all attendees.
 
 ~~~
-<a class="btn" href="https://www.tickettailor.com/checkout/view-event/id/2695671/chk/d255/?modal_widget=true&widget=true">Buy Tickets</a>
+<div style="text-align: center">
+~~~
+> :warning: **The registration is closed**
+~~~
+</div>
 ~~~
 
 # Childcare 


### PR DESCRIPTION
This PR removes links to the tickets and pluto workshop registration, changes the alert baner and hides the tickets box at the main page.