### PR TITLE
Deduplicate Venue entry in headers

### DIFF
--- a/config.md
+++ b/config.md
@@ -148,7 +148,6 @@ configuration = Dict(
             "Venue" => "/2024/venue",
             "Code of Conduct" => "/2024/coc",
             "Call for Proposals" => "https://pretalx.com/juliacon2024/cfp",
-            "Venue" => "/2024/venue",
         ]
     ),
 )


### PR DESCRIPTION
#475 accidentally duplicated the entry Venue in the headers. Fixing it here.