### PR TITLE
[CI] Run previews cleanup on `main` branch

### DIFF
--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - name: Checkout gh-pages branch
+      - name: Checkout main branch
         uses: actions/checkout@v4
         with:
           ref: main
@@ -26,8 +26,8 @@ jobs:
               git config user.email "franklin@juliacon.org"
               git rm -rf "${preview_dir}"
               git commit -m "delete preview"
-              git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
-              git push --force origin gh-pages-new:gh-pages
+              git branch main-new $(echo "delete history" | git commit-tree HEAD^{tree})
+              git push --force origin main-new:main
           fi
         env:
           preview_dir: previews/PR${{ github.event.number }}


### PR DESCRIPTION
I don't have access to settings of this repo, but judging by the fact [this build and deploy job](https://github.com/JuliaCon/www.juliacon.org/actions/runs/7630984939) ran on a commit on `main`, rather than `gh-pages`, my understanding is that we should run the clean-up job on `main`, not `gh-pages`.  For example https://juliacon.org/previews/PR498/2024/ is still there, even if #498 was closed and https://github.com/JuliaCon/www.juliacon.org/actions/runs/7630972233?pr=498 ran successfully.  Also, I have no idea what the `gh-pages` branch is for (maybe only created by this workflow?).

Side note, I believe the `franklin` and `main` branches should be protected, to prevented deletion, and `franklin` shouldn't allow direct pushes and require PRs