### PR TITLE
Fix link for Evovest website

### DIFF
--- a/2024/index.md
+++ b/2024/index.md
@@ -125,7 +125,7 @@ If you are traveling from outside the Schengen area you may need [a visa](/2024/
 \end{centered}
 
 \begin{centered}{title="Startup", margin_bottom="3ex"}
-  \sponsor{name="Evovest", link="https://www.evovest.com", img="/assets/2024/img/sponsors/evovest-logo.svg", level=4}
+  \sponsor{name="Evovest", link="https://evovest.com/", img="/assets/2024/img/sponsors/evovest-logo.svg", level=4}
   \sponsor{name="Genie", link="https://www.genieframework.com", img="/assets/2024/img/sponsors/genie-logo.svg", level=3}
   \sponsor{name="Jolin.io", link="https://www.jolin.io", img="/assets/2024/img/sponsors/jolin-logo.png", level=4}
   \sponsor{name="Jahan.ai", link="https://www.jahan.ai", img="/assets/2024/img/sponsors/jahan-logo.png", level=3}


### PR DESCRIPTION
The certificate is only valid for https://evovest.com/, trying to open https://www.evovest.com/ gives an error message about invalid certificate on most browsers.