### PR TITLE
[CI] Improve concurrency groups

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -8,6 +8,12 @@ on:
     branches:
       - franklin
 
+# Ensure that only one workflow which pushes to the `main` branch is running at a time.
+# Note: this is the same concurrency group as the `cleanup.yml` workflow.
+concurrency:
+  group: pushing-website
+  cancel-in-progress: false
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -4,9 +4,10 @@ on:
   pull_request:
     types: [closed]
 
-# Ensure that only one "Preview Cleanup" workflow is force pushing at a time
+# Ensure that only one workflow which pushes to the `main` branch is running at a time.
+# Note: this is the same concurrency group as the `Deploy.yml` workflow.
 concurrency:
-  group: preview-cleanup
+  group: pushing-website
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
With this change all jobs pushing to the `main` branch (both for deplyoing the website and for cleaning up the previews) share the same concurrency group, to make sure we don't lose commits due to force pushing.