### PR TITLE
JuliaCon 2024: Add the schedule on the website

### DIFF
--- a/2024/index.md
+++ b/2024/index.md
@@ -31,16 +31,17 @@ top_title_heading = "../assets/2021/img/world_768.png 768w, ../assets/2021/img/w
   ~~~
 \end{box}
 
+\begin{box}{title="Talks & Workshop", color="light-blue"}
+  JuliaCon 2024 [schedule is now out](https://pretalx.com/juliacon2024/schedule/)!
+  Besides the awesome talks that will be hosted on July 10th, 11th and 12th, there will also be other activities on the days around the conference! On July 9th [workshops](/2024/workshops) will be held, and on July 13th the annual hackathon will be held. The locations for both activities will be finalized soon.
+\end{box}
+
 \begin{box}{title="Venue", color="light-red"}
   The conference venue will be the [Philips Stadion](https://www.philipsstadion.nl/en/), the home of the [PSV Eindhoven](https://www.psv.nl/english-psv/english-psv.htm) football club, in Eindhoven, Netherlands. Read more about the venue and traveling information [here](/2024/travel).
 
   ~~~
   <iframe src="https://www.google.com/maps/embed?pb=!1m14!1m8!1m3!1d2486.8943504147705!2d5.4648729!3d51.4417341!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x47c6d911c386b16f%3A0x943ec8f52a067b30!2sPhilips%20Stadium!5e0!3m2!1sen!2sus!4v1699467736901!5m2!1sen!2sus" width="100%" height="320" style="border:0;" allowfullscreen></iframe>
   ~~~
-\end{box}
-
-\begin{box}{title="Workshop", color="light-blue"}
-  Besides the awesome talks that will be hosted on July 10th, 11th and 12th, there will also be other activities on the days around the conference! On July 9th workshops will be held, and on July 13th the annual hackathon will be held. The locations for both activities will be finalized soon.
 \end{box}
 
 \begin{box}{title="2023 videos", color="dark-purple"}

--- a/2024/minisymposia.md
+++ b/2024/minisymposia.md
@@ -20,3 +20,5 @@ Minisymposia accepting submissions are tracks in the pretalx system. Simply choo
 "tracks" field when submitting.
 
 By default, deadline for minisymposia is the same of JuliaCon. Some minisymposia organizers may choose to extend the deadline after this has passed. This will be communicated later.
+
+Checkout the full [schedule on PreTalx](https://pretalx.com/juliacon2024/schedule/), or click [here](https://discourse.julialang.org/t/juliacon-2024-schedule-is-now-out/113717/3) for the rest of the announcement and Important FAQs!

--- a/2024/schedule.md
+++ b/2024/schedule.md
@@ -1,1 +1,3 @@
-# Schedule (Coming Soon!)
+# Schedule
+
+Checkout the full [schedule on PreTalx](https://pretalx.com/juliacon2024/schedule/), or click [here](https://discourse.julialang.org/t/juliacon-2024-schedule-is-now-out/113717/3) for the rest of the announcement and Important FAQs!

--- a/2024/workshops.md
+++ b/2024/workshops.md
@@ -2,6 +2,7 @@
 
 **Note!**: This list is preliminary and contains only the workshops that have been confirmed so far. A few more may appear in the upcoming days.
 
+Checkout the full [schedule on PreTalx](https://pretalx.com/juliacon2024/schedule/), or click [here](https://discourse.julialang.org/t/juliacon-2024-schedule-is-now-out/113717/3) for the rest of the announcement and Important FAQs!
 
 ## 	Building REST APIs in Julia
 

--- a/config.md
+++ b/config.md
@@ -138,7 +138,8 @@ configuration = Dict(
         "global" => true,
         "year" => 2024,
         "location" => "Eindhoven",
-        "alert" => """<a href="https://www.tickettailor.com/events/numfocus1/1114995#">Secure your tickets now!</a>""",
+        "alert" => """Checkout the full <a href="https://pretalx.com/juliacon2024/schedule/">schedule on PreTalx</a>, or click <a href="https://discourse.julialang.org/t/juliacon-2024-schedule-is-now-out/113717/3">here</a> for the rest of the announcement and Important FAQs!
+        """,
         "site_name" => "JuliaCon 2024",
         "site_descr" => "JuliaCon 2024, Eindhoven, Philips Stadion",
         "site_url" => "https://juliacon.org/2024/",
@@ -146,9 +147,12 @@ configuration = Dict(
         "header_color" => "#389826",
         "header" => [
             "Tickets" => "/2024/tickets",
+            "Schedule" => [
+                "Talks" => "https://pretalx.com/juliacon2024/schedule/",
+                "Workshops" => "/2024/workshops",
+                "Minisymposia" => "/2024/minisymposia",
+            ],
             "Sponsor" => "/2024/sponsor", 
-            "Workshops" => "/2024/workshops",
-            "Minisymposia" => "/2024/minisymposia",
             "Travel" => "/2024/travel",
             "Volunteer" => "/2024/volunteer",
             "Code of Conduct" => "/2024/coc",


### PR DESCRIPTION
This pull request incorporates the schedule onto various sections of the website. 

<img width="1411" alt="image" src="https://github.com/JuliaCon/www.juliacon.org/assets/6557701/123e9396-ce8a-4e25-b6e7-1a99ec8b46f6">

---

I've moved the 'schedule,' 'workshops,' and 'minisymposia' tabs into a single tab to prevent the navbar from extending excessively and displaying across two rows on smaller monitors.

<img width="561" alt="image" src="https://github.com/JuliaCon/www.juliacon.org/assets/6557701/c0846e21-3a76-4bd6-ac05-7712790afd16">

---

I've also changed the order of items on the main page, placing the schedule directly after the tickets section.

<img width="1256" alt="image" src="https://github.com/JuliaCon/www.juliacon.org/assets/6557701/bd0af89e-4589-4091-95fe-4452ba923ee2">
