### PR TITLE
Move to plausible analytics

### DIFF
--- a/2014/index.html
+++ b/2014/index.html
@@ -16,15 +16,7 @@
         <link rel="stylesheet" href="css/juliacon.css">
         <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
         <script type="text/javascript" src="js/juliacon.js"></script>
-	<script>
-	  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-	  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-	  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	  })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-	  ga('create', 'UA-28835595-3', 'auto');
-	  ga('send', 'pageview');
-	</script>
+	<script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
     </head>
     <body>
         <div class="full-container top-container">

--- a/2015/index-2.html
+++ b/2015/index-2.html
@@ -17,16 +17,7 @@
         <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
         <script type="text/javascript" src="js/juliacon.js"></script>
 
-        <script>
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-          })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-          ga('create', 'UA-28835595-3', 'auto');
-          ga('send', 'pageview');
-
-        </script>
+        <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
     </head>
     <body>
         <div class="full-container top-container">

--- a/2015/index.html
+++ b/2015/index.html
@@ -17,16 +17,7 @@
         <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
         <script type="text/javascript" src="js/juliacon.js"></script>
 
-        <script>
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-          })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-          ga('create', 'UA-28835595-3', 'auto');
-          ga('send', 'pageview');
-
-        </script>
+        <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
     </head>
     <body>
         <div class="full-container top-container">

--- a/2015/talks.html
+++ b/2015/talks.html
@@ -18,16 +18,7 @@
         <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
         <script type="text/javascript" src="js/juliacon.js"></script>
 
-        <script>
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-          })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-          ga('create', 'UA-28835595-3', 'auto');
-          ga('send', 'pageview');
-
-        </script>
+        <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
     </head>
     <body> 
         <div class="full-container" style="height: 15rem;">

--- a/2015/workshops.html
+++ b/2015/workshops.html
@@ -18,16 +18,7 @@
         <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
         <script type="text/javascript" src="js/juliacon.js"></script>
 
-        <script>
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-          })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-          ga('create', 'UA-28835595-3', 'auto');
-          ga('send', 'pageview');
-
-        </script>
+        <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
     </head>
     <body> 
         <div class="full-container" style="height: 15rem;">

--- a/2016/abstracts.html
+++ b/2016/abstracts.html
@@ -17,16 +17,7 @@
         <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
         <script type="text/javascript" src="js/juliacon.js"></script>
 
-        <script>
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-          })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-          ga('create', 'UA-28835595-3', 'auto');
-          ga('send', 'pageview');
-
-        </script>
+        <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
     </head>
     <body>
         <div class="full-container top-container">

--- a/2016/index-2.html
+++ b/2016/index-2.html
@@ -16,17 +16,7 @@
         <link rel="stylesheet" href="css/juliacon.css">
         <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
         <script type="text/javascript" src="js/juliacon.js"></script>
-
-        <script>
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-          })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-          ga('create', 'UA-28835595-3', 'auto');
-          ga('send', 'pageview');
-
-        </script>
+        <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
     </head>
     <body>
         <div class="full-container top-container">

--- a/2016/index.html
+++ b/2016/index.html
@@ -16,17 +16,7 @@
         <link rel="stylesheet" href="css/juliacon.css">
         <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
         <script type="text/javascript" src="js/juliacon.js"></script>
-
-        <script>
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-          })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-          ga('create', 'UA-28835595-3', 'auto');
-          ga('send', 'pageview');
-
-        </script>
+        <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
     </head>
     <body>
         <div class="full-container top-container">

--- a/2016/schedule.html
+++ b/2016/schedule.html
@@ -17,16 +17,7 @@
         <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
         <script type="text/javascript" src="js/juliacon.js"></script>
 
-        <script>
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-          })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-          ga('create', 'UA-28835595-3', 'auto');
-          ga('send', 'pageview');
-
-        </script>
+        <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
     </head>
     <body>
         <div class="full-container top-container">

--- a/2016/workshops.html
+++ b/2016/workshops.html
@@ -17,16 +17,7 @@
         <script src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
         <script type="text/javascript" src="js/juliacon.js"></script>
 
-        <script>
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-          })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-          ga('create', 'UA-28835595-3', 'auto');
-          ga('send', 'pageview');
-
-        </script>
+        <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
     </head>
     <body>
         <div class="full-container top-container">

--- a/2017/coc.html
+++ b/2017/coc.html
@@ -154,17 +154,7 @@ attendance.</p>
 
 </div>
 
-        <script>
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-          })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-          ga('create', 'UA-28835595-3', 'auto');
-          ga('set', 'anonymizeIp', true);
-          ga('send', 'pageview');
-
-        </script>
+        <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
     </body>
 
 <!-- Mirrored from juliacon.org/2017/coc by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:40:36 GMT -->

--- a/2017/index.html
+++ b/2017/index.html
@@ -279,17 +279,7 @@
   <div class="u-vskip-2"></div>
 </div>
 
-        <script>
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-          })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-          ga('create', 'UA-28835595-3', 'auto');
-          ga('set', 'anonymizeIp', true);
-          ga('send', 'pageview');
-
-        </script>
+        <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
     </body>
 
 <!-- Mirrored from juliacon.org/2017/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:40:31 GMT -->

--- a/2017/schedule.html
+++ b/2017/schedule.html
@@ -62,17 +62,7 @@
   <div class="u-vskip-2"></div>
 </div>
 
-        <script>
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-          })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-          ga('create', 'UA-28835595-3', 'auto');
-          ga('set', 'anonymizeIp', true);
-          ga('send', 'pageview');
-
-        </script>
+        <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
     </body>
 
 <!-- Mirrored from juliacon.org/2017/schedule by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:40:36 GMT -->

--- a/2017/talks-2.html
+++ b/2017/talks-2.html
@@ -2058,17 +2058,7 @@ Links:
   <div class="u-vskip-2"></div>
 </div>
 
-        <script>
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-          })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-          ga('create', 'UA-28835595-3', 'auto');
-          ga('set', 'anonymizeIp', true);
-          ga('send', 'pageview');
-
-        </script>
+        <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
     </body>
 
 <!-- Mirrored from juliacon.org/2017/talks.html by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:40:36 GMT -->

--- a/2017/talks.html
+++ b/2017/talks.html
@@ -2058,17 +2058,7 @@ Links:
   <div class="u-vskip-2"></div>
 </div>
 
-        <script>
-          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-          (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-          m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-          })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-          ga('create', 'UA-28835595-3', 'auto');
-          ga('set', 'anonymizeIp', true);
-          ga('send', 'pageview');
-
-        </script>
+        <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
     </body>
 
 <!-- Mirrored from juliacon.org/2017/talks by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:40:36 GMT -->

--- a/2018/accommodation.html
+++ b/2018/accommodation.html
@@ -174,16 +174,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="assets/js/jquery.sticky.js"></script>
     <script src="assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/accommodation.html by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:40:37 GMT -->

--- a/2018/all_talks.html
+++ b/2018/all_talks.html
@@ -4106,16 +4106,7 @@ In this talk you will learn about the underlying building block packages that ma
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="assets/js/jquery.sticky.js"></script>
     <script src="assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/all_talks.html by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:40:31 GMT -->

--- a/2018/coc.html
+++ b/2018/coc.html
@@ -203,16 +203,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="assets/js/jquery.sticky.js"></script>
     <script src="assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/coc by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:40:38 GMT -->

--- a/2018/index.html
+++ b/2018/index.html
@@ -463,16 +463,7 @@ He blogs on www.walkingrandomly.com and tweets at @walkingrandomly</p>
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="assets/js/jquery.sticky.js"></script>
     <script src="assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:40:21 GMT -->

--- a/2018/lightning_talks.html
+++ b/2018/lightning_talks.html
@@ -2124,16 +2124,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="assets/js/jquery.sticky.js"></script>
     <script src="assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/lightning_talks.html by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:00 GMT -->

--- a/2018/posters.html
+++ b/2018/posters.html
@@ -645,16 +645,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="assets/js/jquery.sticky.js"></script>
     <script src="assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/posters.html by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:01 GMT -->

--- a/2018/prize.html
+++ b/2018/prize.html
@@ -150,16 +150,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="assets/js/jquery.sticky.js"></script>
     <script src="assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/prize.html by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:40:36 GMT -->

--- a/2018/schedule.html
+++ b/2018/schedule.html
@@ -132,16 +132,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="assets/js/jquery.sticky.js"></script>
     <script src="assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/schedule by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:40:33 GMT -->

--- a/2018/talks.html
+++ b/2018/talks.html
@@ -1314,16 +1314,7 @@ In this talk you will learn about the underlying building block packages that ma
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="assets/js/jquery.sticky.js"></script>
     <script src="assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks.html by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:40:59 GMT -->

--- a/2018/talks_workshops/1/index.html
+++ b/2018/talks_workshops/1/index.html
@@ -198,16 +198,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/1/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:08 GMT -->

--- a/2018/talks_workshops/100/index.html
+++ b/2018/talks_workshops/100/index.html
@@ -191,16 +191,7 @@ Muresano, R., Pagano, A., 2016. Adapting and Optimizing the Systemic Model of Ba
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/100/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/101/index.html
+++ b/2018/talks_workshops/101/index.html
@@ -423,16 +423,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/101/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/102/index.html
+++ b/2018/talks_workshops/102/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/102/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/103/index.html
+++ b/2018/talks_workshops/103/index.html
@@ -192,16 +192,7 @@ Inspired by the open source spirit (characterizing the julia Comunity) and the s
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/103/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/104/index.html
+++ b/2018/talks_workshops/104/index.html
@@ -191,16 +191,7 @@ I will share with you efforts underway in the Julia community to develop and dis
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/104/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/105/index.html
+++ b/2018/talks_workshops/105/index.html
@@ -191,16 +191,7 @@ Julia is an ideal platform not only for this kind of high-performance, numerical
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/105/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/106/index.html
+++ b/2018/talks_workshops/106/index.html
@@ -199,16 +199,7 @@ We focus our attention on the following topics:</p>
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/106/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/107/index.html
+++ b/2018/talks_workshops/107/index.html
@@ -191,16 +191,7 @@ Building binary dependencies for the wide range of platforms that Julia supports
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/107/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/108/index.html
+++ b/2018/talks_workshops/108/index.html
@@ -192,16 +192,7 @@ Julia has depended on a collection of functions bundled in the C-based openlibm 
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/108/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/109/index.html
+++ b/2018/talks_workshops/109/index.html
@@ -198,16 +198,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/109/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/110/index.html
+++ b/2018/talks_workshops/110/index.html
@@ -195,16 +195,7 @@ We will show that <strong>GSReg.jl</strong> is 4 to 10 times faster than other s
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/110/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/111/index.html
+++ b/2018/talks_workshops/111/index.html
@@ -197,16 +197,7 @@ So what’s new and noteworthy in DataStreams?</p>
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/111/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/112/index.html
+++ b/2018/talks_workshops/112/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/112/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/114/index.html
+++ b/2018/talks_workshops/114/index.html
@@ -222,16 +222,7 @@ This talk is a bottom-up look at the construction of JuliaDB. We will talk about
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/114/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/115/index.html
+++ b/2018/talks_workshops/115/index.html
@@ -192,16 +192,7 @@ Distributed arrays are another key area where one-sided MPI calls can be put to 
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/115/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/116/index.html
+++ b/2018/talks_workshops/116/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/116/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/117/index.html
+++ b/2018/talks_workshops/117/index.html
@@ -192,16 +192,7 @@ This combination provides a powerful workflow for dealing with both large and sm
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/117/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/118/index.html
+++ b/2018/talks_workshops/118/index.html
@@ -194,16 +194,7 @@ I will discuss revisiting Polaron mobility theories from the 1960s (https://gith
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/118/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/119/index.html
+++ b/2018/talks_workshops/119/index.html
@@ -191,16 +191,7 @@ My job at a UK educational research company is to do just that. We work in local
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/119/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/12/index.html
+++ b/2018/talks_workshops/12/index.html
@@ -191,16 +191,7 @@ Julia 1.0 is bringing in a lot of new exciting features to Julia ecosystem. With
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/12/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/120/index.html
+++ b/2018/talks_workshops/120/index.html
@@ -192,16 +192,7 @@ The talk will conclude with an example, showing how to solve the 2D Laplace equa
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/120/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/121/index.html
+++ b/2018/talks_workshops/121/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/121/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/122/index.html
+++ b/2018/talks_workshops/122/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/122/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/123/index.html
+++ b/2018/talks_workshops/123/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/123/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/125/index.html
+++ b/2018/talks_workshops/125/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/125/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/126/index.html
+++ b/2018/talks_workshops/126/index.html
@@ -192,16 +192,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/126/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/127/index.html
+++ b/2018/talks_workshops/127/index.html
@@ -191,16 +191,7 @@ using Parameters @with_kw struct MyT a::Int = 1 # … m = 1:3 # … z::String = 
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/127/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/128/index.html
+++ b/2018/talks_workshops/128/index.html
@@ -201,16 +201,7 @@ In particular, I’ll discuss our work at MIT towards a major goal: controlling 
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/128/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/129/index.html
+++ b/2018/talks_workshops/129/index.html
@@ -191,16 +191,7 @@ We shall also take into account performance comparisons of JIT compiled routines
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/129/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/13/index.html
+++ b/2018/talks_workshops/13/index.html
@@ -192,16 +192,7 @@ Using examples from both personal and commercial projects, I’ll show that many
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/13/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/130/index.html
+++ b/2018/talks_workshops/130/index.html
@@ -191,16 +191,7 @@ Based on experiences in running large scale DAG computations with JuliaDB, this 
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/130/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/14/index.html
+++ b/2018/talks_workshops/14/index.html
@@ -192,16 +192,7 @@ In this talk I will present how BioJulia has developed since 2015 and how we hav
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/14/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/142/index.html
+++ b/2018/talks_workshops/142/index.html
@@ -206,16 +206,7 @@ When he is not glued to a chair gazing at a computer screen, he tries to teach m
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/142/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/143/index.html
+++ b/2018/talks_workshops/143/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/143/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/144/index.html
+++ b/2018/talks_workshops/144/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/144/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/145/index.html
+++ b/2018/talks_workshops/145/index.html
@@ -196,16 +196,7 @@ b) Compare and show some couple of examples from single time-frame systems v/s m
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/145/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/146/index.html
+++ b/2018/talks_workshops/146/index.html
@@ -193,16 +193,7 @@ Julia is the language of choice when it comes to accelerating analyses of large 
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/146/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/147/index.html
+++ b/2018/talks_workshops/147/index.html
@@ -192,16 +192,7 @@ Rob will talk about his field work in the Southern Ocean, his decision to use Ju
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/147/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/148/index.html
+++ b/2018/talks_workshops/148/index.html
@@ -194,16 +194,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/148/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/149/index.html
+++ b/2018/talks_workshops/149/index.html
@@ -191,16 +191,7 @@ I will present an approximate maximum likelihood cost function and concomitant n
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/149/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/15/index.html
+++ b/2018/talks_workshops/15/index.html
@@ -191,16 +191,7 @@ The packages of the <a href="https://juliadynamics.github.io/DynamicalSystems.jl
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/15/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/150/index.html
+++ b/2018/talks_workshops/150/index.html
@@ -194,16 +194,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/150/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/151/index.html
+++ b/2018/talks_workshops/151/index.html
@@ -196,16 +196,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/151/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/152/index.html
+++ b/2018/talks_workshops/152/index.html
@@ -191,16 +191,7 @@ The presentation will balance theory with applications in Julia and the code to 
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/152/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/153/index.html
+++ b/2018/talks_workshops/153/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/153/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/154/index.html
+++ b/2018/talks_workshops/154/index.html
@@ -201,16 +201,7 @@ God bless summer!</p>
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/154/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:11 GMT -->

--- a/2018/talks_workshops/155/index.html
+++ b/2018/talks_workshops/155/index.html
@@ -192,16 +192,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/155/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:11 GMT -->

--- a/2018/talks_workshops/156/index.html
+++ b/2018/talks_workshops/156/index.html
@@ -196,16 +196,7 @@ I once climbed a mountain near Reykjavik while it was hailing and I will never d
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/156/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:11 GMT -->

--- a/2018/talks_workshops/157/index.html
+++ b/2018/talks_workshops/157/index.html
@@ -201,16 +201,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/157/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:11 GMT -->

--- a/2018/talks_workshops/158/index.html
+++ b/2018/talks_workshops/158/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/158/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:11 GMT -->

--- a/2018/talks_workshops/16/index.html
+++ b/2018/talks_workshops/16/index.html
@@ -194,16 +194,7 @@ This talk gives an overview of <em>NMR.jl</em> and how its spectral decompositio
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/16/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/17/index.html
+++ b/2018/talks_workshops/17/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/17/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/18/index.html
+++ b/2018/talks_workshops/18/index.html
@@ -191,16 +191,7 @@ In this talk I’ll discuss the machine learning algorithms we use, approaches f
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/18/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/2/index.html
+++ b/2018/talks_workshops/2/index.html
@@ -205,16 +205,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/2/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/20/index.html
+++ b/2018/talks_workshops/20/index.html
@@ -201,16 +201,7 @@ References &lt;ol type="1"&gt; &lt;li&gt;Buslje, C. M., Santos, J., Delfino, J. 
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/20/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/21/index.html
+++ b/2018/talks_workshops/21/index.html
@@ -192,16 +192,7 @@ The talk will demonstrate application of the new approach in several standard si
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/21/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/22/index.html
+++ b/2018/talks_workshops/22/index.html
@@ -193,16 +193,7 @@ After this talk, you will be empowered to write, compile, and sell software writ
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/22/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/23/index.html
+++ b/2018/talks_workshops/23/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/23/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/24/index.html
+++ b/2018/talks_workshops/24/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/24/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/25/index.html
+++ b/2018/talks_workshops/25/index.html
@@ -195,16 +195,7 @@ ForneyLab relies heavily on Julia’s meta-programming functionality. Not only d
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/25/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/26/index.html
+++ b/2018/talks_workshops/26/index.html
@@ -203,16 +203,7 @@ Since index notation was created for use in scientific domains to describe tenso
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/26/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/27/index.html
+++ b/2018/talks_workshops/27/index.html
@@ -193,16 +193,7 @@ Join me on a quick tour of the main features and learn how to use SearchLight to
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/27/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/28/index.html
+++ b/2018/talks_workshops/28/index.html
@@ -198,16 +198,7 @@ It is divided into three parts:</p>
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/28/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/29/index.html
+++ b/2018/talks_workshops/29/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/29/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/3/index.html
+++ b/2018/talks_workshops/3/index.html
@@ -205,16 +205,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/3/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/30/index.html
+++ b/2018/talks_workshops/30/index.html
@@ -192,16 +192,7 @@ We present the beginnings of such an infrastructure for ecological data analysis
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/30/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/32/index.html
+++ b/2018/talks_workshops/32/index.html
@@ -191,16 +191,7 @@ Some well-known but hard-to-get-right attacks I plan to share may include: block
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/32/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/33/index.html
+++ b/2018/talks_workshops/33/index.html
@@ -195,16 +195,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/33/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/34/index.html
+++ b/2018/talks_workshops/34/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/34/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/35/index.html
+++ b/2018/talks_workshops/35/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/35/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/36/index.html
+++ b/2018/talks_workshops/36/index.html
@@ -195,16 +195,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/36/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/37/index.html
+++ b/2018/talks_workshops/37/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/37/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/38/index.html
+++ b/2018/talks_workshops/38/index.html
@@ -191,16 +191,7 @@ Come learn about our custom Julia stack: how it came together, what we’ve lear
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/38/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/39/index.html
+++ b/2018/talks_workshops/39/index.html
@@ -192,16 +192,7 @@ As we want to make this as automatic and portable as possible, everything runs i
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/39/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/4/index.html
+++ b/2018/talks_workshops/4/index.html
@@ -221,16 +221,7 @@ Weijian Zhang, University of Manchester</p>
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/4/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/40/index.html
+++ b/2018/talks_workshops/40/index.html
@@ -199,16 +199,7 @@ Memento’s main features:</p>
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/40/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/41/index.html
+++ b/2018/talks_workshops/41/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/41/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/42/index.html
+++ b/2018/talks_workshops/42/index.html
@@ -198,16 +198,7 @@ B+-trees are a bit old-fashioned nowadays, so time allowing, we may also try to 
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/42/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/43/index.html
+++ b/2018/talks_workshops/43/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/43/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/44/index.html
+++ b/2018/talks_workshops/44/index.html
@@ -192,16 +192,7 @@ This talk will focus on the key takeaways from my interactions with an advocacy 
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/44/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/45/index.html
+++ b/2018/talks_workshops/45/index.html
@@ -197,16 +197,7 @@ A lot of functionality is being worked on right now. This includes a dozen build
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/45/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/46/index.html
+++ b/2018/talks_workshops/46/index.html
@@ -191,16 +191,7 @@ I will describe a package, Revise.jl, that automates much of the work of the tes
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/46/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/47/index.html
+++ b/2018/talks_workshops/47/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/47/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/48/index.html
+++ b/2018/talks_workshops/48/index.html
@@ -197,16 +197,7 @@ We believe that the above application is useful to people who are suffering from
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/48/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/49/index.html
+++ b/2018/talks_workshops/49/index.html
@@ -192,16 +192,7 @@ This talk will demonstrate how I solve many optimisation and statistical problem
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/49/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/5/index.html
+++ b/2018/talks_workshops/5/index.html
@@ -205,16 +205,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/5/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/50/index.html
+++ b/2018/talks_workshops/50/index.html
@@ -192,16 +192,7 @@ We will focus on showing how Taylor models can be used as a building block to so
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/50/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/51/index.html
+++ b/2018/talks_workshops/51/index.html
@@ -192,16 +192,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/51/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/52/index.html
+++ b/2018/talks_workshops/52/index.html
@@ -191,16 +191,7 @@ To maximally simplify the user experience, we try to support both grouped data a
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/52/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/53/index.html
+++ b/2018/talks_workshops/53/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/53/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/54/index.html
+++ b/2018/talks_workshops/54/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/54/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/55/index.html
+++ b/2018/talks_workshops/55/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/55/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/56/index.html
+++ b/2018/talks_workshops/56/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/56/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/57/index.html
+++ b/2018/talks_workshops/57/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/57/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/59/index.html
+++ b/2018/talks_workshops/59/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/59/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/6/index.html
+++ b/2018/talks_workshops/6/index.html
@@ -207,16 +207,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/6/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/60/index.html
+++ b/2018/talks_workshops/60/index.html
@@ -191,16 +191,7 @@ Julia has the potential to remediate to this situation. It offers a platform whe
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/60/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/61/index.html
+++ b/2018/talks_workshops/61/index.html
@@ -191,16 +191,7 @@ Pharmacokinetic and Pharmacodynamic (PK/PD) models are one such class of models 
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/61/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/62/index.html
+++ b/2018/talks_workshops/62/index.html
@@ -193,16 +193,7 @@ Generalization for higher dimensions In many applications, the roots of a system
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/62/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/63/index.html
+++ b/2018/talks_workshops/63/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/63/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/64/index.html
+++ b/2018/talks_workshops/64/index.html
@@ -193,16 +193,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/64/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/65/index.html
+++ b/2018/talks_workshops/65/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/65/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/66/index.html
+++ b/2018/talks_workshops/66/index.html
@@ -191,16 +191,7 @@ We used Julia to assess the overall problem and how it affected experiments at E
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/66/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/67/index.html
+++ b/2018/talks_workshops/67/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/67/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/68/index.html
+++ b/2018/talks_workshops/68/index.html
@@ -197,16 +197,7 @@ I’ll give a quick overview of the tricks of the trade:</p>
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/68/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/69/index.html
+++ b/2018/talks_workshops/69/index.html
@@ -192,16 +192,7 @@ Demo! We will live-code a simple graph type defined by its adjacency matrix and 
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/69/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/7/index.html
+++ b/2018/talks_workshops/7/index.html
@@ -203,16 +203,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/7/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/72/index.html
+++ b/2018/talks_workshops/72/index.html
@@ -191,16 +191,7 @@ When training on heterogeneous types of data, the choice of the hyperparameters 
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/72/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/73/index.html
+++ b/2018/talks_workshops/73/index.html
@@ -193,16 +193,7 @@ In this talk, I’ll discuss Cassette’s design, implementation, and show how i
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/73/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/74/index.html
+++ b/2018/talks_workshops/74/index.html
@@ -229,16 +229,7 @@ Once you’ve got the data onto your machine, the final stage is to load it up i
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/74/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/75/index.html
+++ b/2018/talks_workshops/75/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/75/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/76/index.html
+++ b/2018/talks_workshops/76/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/76/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/77/index.html
+++ b/2018/talks_workshops/77/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/77/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/78/index.html
+++ b/2018/talks_workshops/78/index.html
@@ -192,16 +192,7 @@ and finally, I will reflect upon how the Julia features that allowed the making 
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/78/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/79/index.html
+++ b/2018/talks_workshops/79/index.html
@@ -192,16 +192,7 @@ We will present developments in the JuliaGraphs community and celebrate the 1.0 
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/79/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/8/index.html
+++ b/2018/talks_workshops/8/index.html
@@ -231,16 +231,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/8/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/80/index.html
+++ b/2018/talks_workshops/80/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/80/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/81/index.html
+++ b/2018/talks_workshops/81/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/81/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/82/index.html
+++ b/2018/talks_workshops/82/index.html
@@ -192,16 +192,7 @@ The work described here was conducted at the University of British Columbia and 
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/82/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/83/index.html
+++ b/2018/talks_workshops/83/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/83/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/84/index.html
+++ b/2018/talks_workshops/84/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/84/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/85/index.html
+++ b/2018/talks_workshops/85/index.html
@@ -194,16 +194,7 @@ In this talk I’ll introduce my new tool for interactive program analysis, aka 
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/85/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/86/index.html
+++ b/2018/talks_workshops/86/index.html
@@ -195,16 +195,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/86/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/87/index.html
+++ b/2018/talks_workshops/87/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/87/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/88/index.html
+++ b/2018/talks_workshops/88/index.html
@@ -192,16 +192,7 @@ This presentation examines how Julia’s unique properties make it ideal for tac
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/88/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/89/index.html
+++ b/2018/talks_workshops/89/index.html
@@ -191,16 +191,7 @@ Together with additional package OptionPrice.jl, which implements fast and accur
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/89/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/90/index.html
+++ b/2018/talks_workshops/90/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/90/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/91/index.html
+++ b/2018/talks_workshops/91/index.html
@@ -201,16 +201,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/91/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/92/index.html
+++ b/2018/talks_workshops/92/index.html
@@ -195,16 +195,7 @@ Live demonstration showing how to set up your own forecasting system using TIM i
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/92/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/93/index.html
+++ b/2018/talks_workshops/93/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/93/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/94/index.html
+++ b/2018/talks_workshops/94/index.html
@@ -192,16 +192,7 @@ Come get up to speed on the latest and greatest web functionality in Julia and l
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/94/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/95/index.html
+++ b/2018/talks_workshops/95/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/95/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/96/index.html
+++ b/2018/talks_workshops/96/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/96/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/97/index.html
+++ b/2018/talks_workshops/97/index.html
@@ -190,16 +190,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/97/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/talks_workshops/98/index.html
+++ b/2018/talks_workshops/98/index.html
@@ -193,16 +193,7 @@ We have also attempted to base our work on Julia “ecosystems” like <a href="
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../../assets/js/jquery.sticky.js"></script>
     <script src="../../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/talks_workshops/98/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:41:09 GMT -->

--- a/2018/tickets.html
+++ b/2018/tickets.html
@@ -169,16 +169,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="assets/js/jquery.sticky.js"></script>
     <script src="assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/tickets.html by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:40:34 GMT -->

--- a/2018/workshops.html
+++ b/2018/workshops.html
@@ -392,16 +392,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="assets/js/jquery.sticky.js"></script>
     <script src="assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2018/workshops.html by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:40:58 GMT -->

--- a/2019/coc.html
+++ b/2019/coc.html
@@ -210,16 +210,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="assets/js/jquery.sticky.js"></script>
     <script src="assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2019/coc by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:39:24 GMT -->

--- a/2019/committee.html
+++ b/2019/committee.html
@@ -161,16 +161,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="assets/js/jquery.sticky.js"></script>
     <script src="assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2019/committee.html by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:39:24 GMT -->

--- a/2019/financial-assistance/index.html
+++ b/2019/financial-assistance/index.html
@@ -150,16 +150,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../assets/js/jquery.sticky.js"></script>
     <script src="../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2019/financial-assistance/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:39:25 GMT -->

--- a/2019/index.html
+++ b/2019/index.html
@@ -677,16 +677,7 @@ including the textbook <em>Photonic Crystals: Molding the Flow of Light</em>.</p
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="assets/js/jquery.sticky.js"></script>
     <script src="assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2019/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:39:22 GMT -->

--- a/2019/prize.html
+++ b/2019/prize.html
@@ -157,16 +157,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="assets/js/jquery.sticky.js"></script>
     <script src="assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2019/prize.html by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:39:24 GMT -->

--- a/2019/sponsor/index.html
+++ b/2019/sponsor/index.html
@@ -203,16 +203,7 @@ JuliaCon 2019 sponsorship comes with the following benefits:
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../assets/js/jquery.sticky.js"></script>
     <script src="../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2019/sponsor/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:39:24 GMT -->

--- a/2019/tickets/index.html
+++ b/2019/tickets/index.html
@@ -169,16 +169,7 @@
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../assets/js/jquery.sticky.js"></script>
     <script src="../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2019/tickets/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:39:24 GMT -->

--- a/2019/volunteer/index.html
+++ b/2019/volunteer/index.html
@@ -186,16 +186,7 @@ Please let us know if you would like to be mentored or if you are willing to men
     <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
     <script src="../assets/js/jquery.sticky.js"></script>
     <script src="../assets/js/juliacon.js"></script>
-    <script>
-        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-            (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','http://www.google-analytics.com/analytics.js','ga');
-
-        ga('create', 'UA-28835595-3', 'auto');
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
+    <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
 </body>
 
 <!-- Mirrored from juliacon.org/2019/volunteer/ by HTTrack Website Copier/3.x [XR&CO'2014], Mon, 25 Jan 2021 09:39:24 GMT -->

--- a/_layout/foot.html
+++ b/_layout/foot.html
@@ -24,16 +24,5 @@
 <script src="/libs/jquery.sticky.js"></script>
 <script src="/libs/juliacon.js"></script>
 
-<script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-
-    ga('create', 'UA-28835595-3', 'auto');
-    ga('set', 'anonymizeIp', true);
-    ga('send', 'pageview');
-</script>
-
   </body>
 </html>

--- a/_layout/head.html
+++ b/_layout/head.html
@@ -42,6 +42,9 @@
   <script>try{Typekit.load({ async: true });}catch(e){}</script>
 
   <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+  
+  <script defer data-domain="juliacon.org" src="https://plausible.io/js/script.js"></script>
+
 </head>
 <body>
 


### PR DESCRIPTION
Move to a more privacy friendly analytics with [Plausible](https://plausible.io/), removing Google Analytics. This will obviate any need to have a cookie banner on the site. 