### PR TITLE
Fix link to the community prize nominations

### DIFF
--- a/2024/index.md
+++ b/2024/index.md
@@ -185,7 +185,7 @@ We also have some photographic memories from previous JuliaCons. Explore our col
   <div class="row masonry" data-masonry='{ "itemSelector": ".grid-item", "percentPosition": true }'>
 ~~~
 \begin{box}{title="Julia Community Prize 2024", color="red"}
-  Nominations for the Julia Community Prize 2024 are now open! [Send us your nominations today]([/2023/prize/](https://forms.gle/Jn6RTeqwNWbpX7tM8)).
+  Nominations for the Julia Community Prize 2024 are now open! [Send us your nominations today](https://forms.gle/Jn6RTeqwNWbpX7tM8).
 \end{box}
 
 \begin{box}{title="Diversity Initiative & Childcare", color="purple"}


### PR DESCRIPTION
## Briefly Describe your changes

The link to the nominations Google form was incorrectly formatted I think.

## Checklist for merge
- [x] I built the website locally and tested it using `Franklin.serve()`
- [x] All CI checks have passed and you have tested the online version (click on the list of checks and click `Build and Deploy / Preview` to see the preview)
- [ ] Somebody else reviewed my changes (use your best judgement if you need to merge quickly

## After merge
- [ ] Closed relevant issues
