### PR TITLE
Set `suppress_errors=false` in Franklin build

### DIFF
--- a/.github/workflows/Deploy.yml
+++ b/.github/workflows/Deploy.yml
@@ -49,7 +49,7 @@ jobs:
         Pkg.instantiate()
 
         using Franklin
-        optimize(minify=false, prerender=false)
+        optimize(minify=false, prerender=false, suppress_errors=false)
     - name: Deploy (preview)
       if: github.event_name == 'pull_request' && ! github.event.pull_request.head.repo.fork # if this build is a PR build and the PR is NOT from a fork
       uses: JamesIves/github-pages-deploy-action@releases/v4


### PR DESCRIPTION
We broke the JuliaCon website on the first day because an error was suppressed.  The error had been live for a while, but a change to surrounding code caused it to move from minor annoyance to catastrophic.  This moves us to a stricter mode where such errors are not allowed at all.

## Briefly Describe your changes

## Checklist for merge
- [x] I built the website locally and tested it using `Franklin.serve()`
- [ ] All CI checks have passed and you have tested the online version (click on the list of checks and click `Build and Deploy / Preview` to see the preview)
- [x] Somebody else reviewed my changes (use your best judgement if you need to merge quickly

## After merge
- [ ] Closed relevant issues
