### PR TITLE
Add movies on the main page eindhoven 2024

### DIFF
--- a/2024/index.md
+++ b/2024/index.md
@@ -42,6 +42,41 @@ Besides the awesome talks that will be hosted on July 10th, 11th and 12th, there
   @@
 @@
 
+\begin{rowheader}{title="JuliaCon 2024 Highlights", color=""}\end{rowheader}
+\\
+@@row,row-section
+@@col-12
+## Day 2 Highlights - JuliaCon & PyData Eindhoven
+~~~
+<iframe width="100%" style="aspect-ratio: 16 / 9;" src="https://www.youtube.com/embed/N8kEFjGhos4?si=pqkHIMH6aWX7-wWQ" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+~~~
+\\
+Experience the highlights of Day 2, featuring the special collaboration between JuliaCon and PyData Eindhoven! This unique day brought together the Julia and Python communities for an exciting exchange of ideas and knowledge.
+@@
+@@
+\\
+@@row,row-section
+@@col-12,col-md-4
+## Preparations
+~~~
+<iframe width="100%" style="aspect-ratio: 16 / 9;" src="https://www.youtube.com/embed/srIrEIR9Fhg?si=lkgNAsriZX7ozh7X" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+~~~
+@@
+@@col-12,col-md-4
+## Day 1 Highlights
+~~~
+<iframe width="100%" style="aspect-ratio: 16 / 9;" src="https://www.youtube.com/embed/k23pQq8HUes?si=Q-a_HcVe6n84YpUF" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+~~~
+@@
+@@col-12,col-md-4
+## Day 3 & Hackathon
+~~~
+<iframe width="100%" style="aspect-ratio: 16 / 9;" src="https://www.youtube.com/embed/_RLQNpHbq7o?si=rRuQIBEvv4-0kyYI" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+~~~
+@@
+@@
+\\
+
 @@row,row-section
 \begin{glancecard}{title="Passionate community", img="/assets/2024/img/whattoexpect/community.jpg", color="purple"}
   At JuliaCon, expect to be surrounded by passionate individuals from diverse backgrounds united by their enthusiasm for the Julia programming language. 


### PR DESCRIPTION
## Briefly Describe your changes

This PR adds videos that I made for each day of Eindhoven 2024 on the main page.

<img width="1624" height="984" alt="Screenshot 2025-07-11 at 19 07 34" src="https://github.com/user-attachments/assets/f3f82d32-4f04-4e08-821b-e025d15b29c5" />
<img width="1624" height="984" alt="Screenshot 2025-07-11 at 19 07 31" src="https://github.com/user-attachments/assets/6bc47929-904b-488d-9ce0-ac32d5d6809c" />

The Day 2 is highlighted because it was a joint event with PyData :) 

## Checklist for merge
- [x] I built the website locally and tested it using `Franklin.serve()`
- [ ] All CI checks have passed and you have tested the online version (click on the list of checks and click `Build and Deploy / Preview` to see the preview)
- [ ] Somebody else reviewed my changes (use your best judgement if you need to merge quickly

## After merge
- [ ] Closed relevant issues
