### PR TITLE
Update name of GITHUB_TOKEN option in compress images workflow

### DIFF
--- a/.github/workflows/compress-images.yaml
+++ b/.github/workflows/compress-images.yaml
@@ -18,7 +18,7 @@ jobs:
         id: calibre
         uses: calibreapp/image-actions@1.2.0
         with:
-          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           compressOnly: true
       - name: Create New Pull Request If Needed
         if: steps.calibre.outputs.markdown != ''


### PR DESCRIPTION
## Briefly Describe your changes

## Checklist for merge
- [ ] I built the website locally and tested it using `Franklin.serve()`
- [ ] All CI checks have passed and you have tested the online version (click on the list of checks and click `Build and Deploy / Preview` to see the preview)
- [ ] Somebody else reviewed my changes (use your best judgement if you need to merge quickly

## After merge
- [ ] Closed relevant issues
