### PR TITLE
Add 2025 community prize winners

### DIFF
--- a/2025/index.md
+++ b/2025/index.md
@@ -17,12 +17,8 @@ top_title_heading = "../assets/2021/img/world_768.png 768w, ../assets/2021/img/w
 [Get your ticket today!](/2025/tickets/)
 \end{box}
 
-<!-- \begin{box}{title="UPitt Housing Now Available", color="purple"}
-Head to the UPitt Housing Portal [here](https://panthercentralpitt.wufoo.com/forms/juliacon-2025-housing-request/) to purchase housing on UPitt's campus for JuliaCon 2025. An FAQ can be found [here](/2025/housing).
-\end{box} -->
-
-\begin{box}{title="Letter of Invitation", color="red"}
-If you require a supporting letter of invitation for a visa application or to enter the United States, please fill out [this form](https://forms.gle/thnxVEw2qpZUAH2d9). 
+\begin{box}{title="Recording", color="red"}
+If you require a supporting jletter of invitation for a visa application or to enter the United States, please fill out [this form](https://forms.gle/thnxVEw2qpZUAH2d9). 
 \end{box}
 
 \begin{box}{title="Review accessibility presentation guidelines", color="purple"}
@@ -30,7 +26,7 @@ To make your presentation accessible to everyone, review the [JuliaCon accessibi
 \end{box}
 
 \begin{box}{title="Community Prize 2025", color="dark-green"}
-Recognize great work by [nominating someone](https://forms.gle/dC2gtbcAxACPUxcr5) for the 2025 Julia Community Prize. Winners will be announced at JuliaCon!
+The winners of the [Community Prize 2025](prize/) have been accounced. 
 \end{box}
 
 ~~~

--- a/2025/prize.md
+++ b/2025/prize.md
@@ -1,17 +1,14 @@
 # Julia Community Prize
 
-The Julia Community Prize 2024 winners have been announced! Winners recieve a certificate of accomplishment and a cash award of USD 1000 shared among each group.
+The Julia Community Prize 2025 winners have been announced! Winners recieve a certificate of accomplishment and a cash award of USD 1000.
 
-## 2024 Community Prize Winners: 
+## 2025 Community Prize Winners: 
 
-### Guillaume Dalle 
-For their various contributions to the Julia ecosystem including DifferentiationInterface and the Modern Julia Workflows guide.
+### Claire Foster  
+For their work on JuliaSyntax and JuliaLowering.
 
-### The Makie team (Simon Danisch, Julius Krumbiegel, Frederic Freyer, and Anshul Singhvi)
-For their contributions to Makie and improving interactive data visualization in Julia.
-
-### The JuMP team (Oscar Dowson, Benoît Legat, and Miles Lubin)
-For their long term commitment and contributions to JuMP.
+### Stefan Krastanov
+For their effort in organizing the Quantum Community and the "This Month in Julia World" newsletter. 
 
 ## Awards Committee
 


### PR DESCRIPTION
## Briefly Describe your changes
Add 2025 Community Prize winners to the website. 

## Checklist for merge
- [x] I built the website locally and tested it using `Franklin.serve()`
- [ ] All CI checks have passed and you have tested the online version (click on the list of checks and click `Build and Deploy / Preview` to see the preview)
- [ ] Somebody else reviewed my changes (use your best judgement if you need to merge quickly

## After merge
- [ ] Closed relevant issues
